### PR TITLE
Support private DBs in database fetcher

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -2,6 +2,7 @@
 
 const co = require('co')
 const debug = require('./debug')
+const pgUtil = require('./util')
 
 module.exports = heroku => {
   function * addon (app, db) {
@@ -14,23 +15,13 @@ module.exports = heroku => {
   }
 
   function * database (app, db) {
-    const url = require('url')
-
     let addonID = (yield module.exports(heroku).addon(app, db)).id
     let [addon, config] = yield [
       heroku.get(`/addons/${addonID}`),
       heroku.get(`/apps/${app}/config-vars`)
     ]
 
-    db = url.parse(config[addon.config_vars[0]])
-    let [user, password] = db.auth.split(':')
-    return {
-      user,
-      password,
-      database: db.path.split('/', 2)[1],
-      host: db.hostname,
-      port: db.port
-    }
+    return pgUtil.getConnectionDetails(addon, config)
   }
 
   function * all (app) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,56 @@
+const debug = require('./debug')
+const url = require('url')
+const sample = require('lodash.sample')
+
+const getBastion = function (config, baseName) {
+  // If there are bastions, extract a host and a key
+  // otherwise, return an empty Object
+
+  // If there are bastions:
+  // * there should be one *_BASTION_KEY
+  // * pick one host from the comma-separated list in *_BASTIONS
+  // We assert that _BASTIONS and _BASTION_KEY always exist together
+  // If either is falsy, pretend neither exist
+
+  const bastionKey = config[`${baseName}_BASTION_KEY`]
+  const bastionHost = sample(config[`${baseName}_BASTIONS`].split(','))
+  return (!(bastionKey && bastionHost))
+    ? {}
+    : {bastionHost, bastionKey}
+}
+
+exports.getConnectionDetails = function (addon, config) {
+  const connstrings = addon.config_vars
+    .filter((cv) => (
+      config[cv].startsWith('postgres://')
+      && cv.endsWith('_URL')
+    ))
+
+  if (connstrings.length === 0) {
+    // TODO blow up in a useful fashion
+  }
+
+  const baseName = connstrings[0].slice(0, -4)
+
+  // build the default payload for non-bastion dbs
+  debug(`Using "${connstrings[0]}" to connect to your database…`)
+  const target = url.parse(config[connstrings[0]])
+  let [user, password] = target.auth.split(':')
+
+  let payload = {
+    user,
+    password,
+    database: target.path.split('/', 2)[1],
+    host: target.hostname,
+    port: target.port
+  }
+
+  // If bastion creds exist, graft it into the payload
+  const bastion = getBastion(config, baseName)
+  if (bastion) {
+    Object.assign(payload, bastion)
+  }
+
+  console.log(payload)
+  return payload
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,7 +13,7 @@ const getBastion = function (config, baseName) {
   // If either is falsy, pretend neither exist
 
   const bastionKey = config[`${baseName}_BASTION_KEY`]
-  const bastionHost = sample(config[`${baseName}_BASTIONS`].split(','))
+  const bastionHost = sample((config[`${baseName}_BASTIONS`] || '').split(','))
   return (!(bastionKey && bastionHost))
     ? {}
     : {bastionHost, bastionKey}
@@ -22,12 +22,13 @@ const getBastion = function (config, baseName) {
 exports.getConnectionDetails = function (addon, config) {
   const connstrings = addon.config_vars
     .filter((cv) => (
-      config[cv].startsWith('postgres://')
-      && cv.endsWith('_URL')
+      config[cv].startsWith('postgres://') &&
+      cv.endsWith('_URL')
     ))
 
   if (connstrings.length === 0) {
-    cli.error(`Database URL not found for this addon`)
+    const cli = require('heroku-cli-util')
+    cli.error('Database URL not found for this addon')
   }
 
   const baseName = connstrings[0].slice(0, -4)

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,21 +20,22 @@ const getBastion = function (config, baseName) {
 }
 
 exports.getConnectionDetails = function (addon, config) {
-  const connstrings = addon.config_vars
+  const connstringVars = addon.config_vars
     .filter((cv) => (
       config[cv].startsWith('postgres://') &&
       cv.endsWith('_URL')
     ))
 
-  if (connstrings.length === 0) {
+  if (connstringVars.length === 0) {
     throw new Error('Database URL not found for this addon')
   }
 
-  const baseName = connstrings[0].slice(0, -4)
+  // remove _URL from the end of the config var name
+  const baseName = connstringVars[0].slice(0, -4)
 
   // build the default payload for non-bastion dbs
-  debug(`Using "${connstrings[0]}" to connect to your database…`)
-  const target = url.parse(config[connstrings[0]])
+  debug(`Using "${connstringVars[0]}" to connect to your database…`)
+  const target = url.parse(config[connstringVars[0]])
   let [user, password] = target.auth.split(':')
 
   let payload = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,7 +27,7 @@ exports.getConnectionDetails = function (addon, config) {
     ))
 
   if (connstrings.length === 0) {
-    // TODO blow up in a useful fashion
+    cli.error(`Database URL not found for this addon`)
   }
 
   const baseName = connstrings[0].slice(0, -4)

--- a/lib/util.js
+++ b/lib/util.js
@@ -27,8 +27,7 @@ exports.getConnectionDetails = function (addon, config) {
     ))
 
   if (connstrings.length === 0) {
-    const cli = require('heroku-cli-util')
-    cli.error('Database URL not found for this addon')
+    throw new Error('Database URL not found for this addon')
   }
 
   const baseName = connstrings[0].slice(0, -4)

--- a/lib/util.js
+++ b/lib/util.js
@@ -51,6 +51,5 @@ exports.getConnectionDetails = function (addon, config) {
     Object.assign(payload, bastion)
   }
 
-  console.log(payload)
   return payload
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "heroku-cli-addons": "1.0.5",
     "heroku-cli-util": "6.0.15",
     "lodash.flatten": "4.4.0",
+    "lodash.sample": "4.2.1",
     "lodash.sortby": "4.6.1",
     "lodash.uniqby": "4.6.1",
     "string": "3.3.1",


### PR DESCRIPTION
Currently, all plugins such as heroku-pg-extras fail on fetching the database payload (https://github.com/heroku/heroku-pg-extras/issues/137). 

This is because we cannot rely on `addon.config_vars[0]` being the database url in the private database case because of the presence of bastion URLs in the config vars. 
