### PR TITLE
Replace all instances of config_vars[0]

### DIFF
--- a/commands/copy.js
+++ b/commands/copy.js
@@ -5,6 +5,7 @@ const cli = require('heroku-cli-util')
 
 function * run (context, heroku) {
   const url = require('url')
+  const util = require('../lib/util')
   const host = require('../lib/host')
   const pgbackups = require('../lib/pgbackups')(context, heroku)
   const addons = require('heroku-cli-addons').resolve
@@ -31,7 +32,7 @@ function * run (context, heroku) {
       attachment.addon = addon
       return {
         name: attachment.name.replace(/^HEROKU_POSTGRESQL_/, '').replace(/_URL$/, ''),
-        url: config[addon.config_vars[0]],
+        url: config[util.getUrl(addon.config_vars)],
         attachment,
         confirm: app
       }

--- a/commands/diagnose.js
+++ b/commands/diagnose.js
@@ -15,10 +15,10 @@ function * run (context, heroku) {
     db = yield heroku.get(`/addons/${db.name}`)
     let config = yield heroku.get(`/apps/${app}/config-vars`)
     let params = {
-      url: config[db.config_vars[0]],
+      url: config[util.getUrl(db.config_vars)],
       plan: db.plan.name,
       app: db.app.name,
-      database: db.config_vars[0]
+      database: util.getUrl(db.config_vars)
     }
     if (!util.starterPlan(db)) {
       params.metrics = yield heroku.get(`/client/v11/databases/${db.name}/metrics`, {host: host(db)})

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -41,7 +41,8 @@ function * exec (db, query) {
 
 function * interactive (db) {
   const {spawnSync} = require('child_process')
-  let name = db.attachment.config_vars[0].replace(/^HEROKU_POSTGRESQL_/, '').replace(/_URL$/, '')
+  const pgUtil = require('./util')
+  let name = pgUtil.getUrl(db.attachment.config_vars).replace(/^HEROKU_POSTGRESQL_/, '').replace(/_URL$/, '')
   let prompt = `${db.attachment.app.name}::${name}%R%# `
   handleSignals()
   let {error: err, status} = spawnSync('psql',

--- a/lib/util.js
+++ b/lib/util.js
@@ -21,22 +21,24 @@ const getBastion = function (config, baseName) {
     : {bastionHost, bastionKey}
 }
 
+function getUrl (configVars) {
+  let connstringVars = configVars.filter((cv) => (cv.endsWith('_URL')))
+  if (connstringVars.length === 0) throw new Error('Database URL not found for this addon')
+  return connstringVars[0]
+}
+
+exports.getUrl = getUrl
+
 exports.getConnectionDetails = function (attachment, config) {
   const url = require('url')
-  const connstringVars = attachment.config_vars
-    .filter((cv) => (
-      config[cv].startsWith('postgres://') &&
-      cv.endsWith('_URL')
-    ))
-
-  if (connstringVars.length === 0) throw new Error('Database URL not found for this addon')
+  const connstringVar = getUrl(attachment.config_vars.filter((cv) => config[cv].startsWith('postgres://')))
 
   // remove _URL from the end of the config var name
-  const baseName = connstringVars[0].slice(0, -4)
+  const baseName = connstringVar.slice(0, -4)
 
   // build the default payload for non-bastion dbs
-  debug(`Using "${connstringVars[0]}" to connect to your database…`)
-  const target = url.parse(config[connstringVars[0]])
+  debug(`Using "${connstringVar}" to connect to your database…`)
+  const target = url.parse(config[connstringVar])
   let [user, password] = target.auth.split(':')
 
   let payload = {


### PR DESCRIPTION
@dickeyxxx could you review?  Since `config_vars.length > 1` in the case of bastion hosts, I thought it best to not depend on order, and instead grep out the one that ends in `_URL`.