### PR TITLE
Wait on correct app

### DIFF
--- a/commands/copy.js
+++ b/commands/copy.js
@@ -47,8 +47,9 @@ This command will remove all data from ${cli.color.yellow(target.name)}
 Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.color.yellow(target.name)}`)
 
   let copy
+  let attachment
   yield cli.action(`Starting copy of ${cli.color.yellow(source.name)} to ${cli.color.yellow(target.name)}`, co(function * () {
-    let attachment = source.attachment || target.attachment
+    attachment = source.attachment || target.attachment
     if (!attachment) throw new Error('Heroku PostgreSQL database must be source or target')
     copy = yield heroku.post(`/client/v11/databases/${attachment.addon.name}/transfers`, {
       body: {
@@ -60,7 +61,7 @@ Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.col
       host: host(attachment.addon)
     })
   }))
-  yield pgbackups.wait('Copying', copy.uuid, interval, flags.verbose)
+  yield pgbackups.wait('Copying', copy.uuid, interval, flags.verbose, attachment.addon.app.name)
 }
 
 module.exports = {

--- a/lib/pgbackups.js
+++ b/lib/pgbackups.js
@@ -64,7 +64,10 @@ module.exports = (context, heroku) => ({
       }
     }
   },
-  wait: (action, transferID, interval, verbose) => {
+  wait: (action, transferID, interval, verbose, app) => {
+    if (app === undefined) {
+      app = context.app
+    }
     const wait = require('co-wait')
     const host = require('./host')()
     const pgbackups = module.exports(context, heroku)
@@ -85,7 +88,7 @@ module.exports = (context, heroku) => ({
 
       while (true) {
         try {
-          backup = yield heroku.get(`/client/v11/apps/${context.app}/transfers/${transferID}`, {host})
+          backup = yield heroku.get(`/client/v11/apps/${app}/transfers/${transferID}`, {host})
         } catch (err) {
           if (failures++ > 20) throw err
         }


### PR DESCRIPTION
Copies can be associated with the source or target, depending on which
one is actually a heroku-postgresql add-on. Right now, we assume that
the context app is the one to wait on, but that's not always the case.
Overload wait to allow waiting for the correct thing.

@keiko713 can you try this branch and see if it fixes the problem?