### PR TITLE
Use bastions to tunnel in pg:pull & pg:push

### DIFF
--- a/commands/pull.js
+++ b/commands/pull.js
@@ -40,7 +40,11 @@ function spawn (cmd) {
       result += data.toString()
     })
     psql.on('close', function (code) {
-      resolve(result)
+      if (code === 0) {
+        resolve(result)
+      } else {
+        cli.exit(code)
+      }
     })
   })
 }

--- a/lib/bastion.js
+++ b/lib/bastion.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const debug = require('./debug')
+const tunnel = require('tunnel-ssh')
+
+const getBastion = function (config, baseName) {
+  const sample = require('lodash.sample')
+  // If there are bastions, extract a host and a key
+  // otherwise, return an empty Object
+
+  // If there are bastions:
+  // * there should be one *_BASTION_KEY
+  // * pick one host from the comma-separated list in *_BASTIONS
+  // We assert that _BASTIONS and _BASTION_KEY always exist together
+  // If either is falsy, pretend neither exist
+
+  const bastionKey = config[`${baseName}_BASTION_KEY`]
+  const bastionHost = sample((config[`${baseName}_BASTIONS`] || '').split(','))
+  return (!(bastionKey && bastionHost))
+    ? {}
+    : {bastionHost, bastionKey}
+}
+
+exports.getBastion = getBastion
+
+const env = function (db) {
+  return Object.assign({}, process.env, {
+    PGAPPNAME: 'psql non-interactive',
+    PGSSLMODE: db.hostname === 'localhost' ? 'prefer' : 'require',
+    PGUSER: db.user || '',
+    PGPASSWORD: db.password,
+    PGDATABASE: db.database,
+    PGPORT: db.port || 5432,
+    PGHOST: db.host
+  })
+}
+
+exports.env = env
+
+function tunnelConfig (db) {
+  const localHost = '127.0.0.1'
+  const localPort = Math.floor(Math.random() * (65535 - 49152) + 49152)
+  return {
+    username: 'bastion',
+    host: db.bastionHost,
+    privateKey: db.bastionKey,
+    dstHost: db.host,
+    dstPort: db.port,
+    localHost: localHost,
+    localPort: localPort
+  }
+}
+
+exports.tunnelConfig = tunnelConfig
+
+function getConfigs (db) {
+  let dbEnv = env(db)
+  const dbTunnelConfig = tunnelConfig(db)
+  if (db.bastionKey) {
+    dbEnv = Object.assign(dbEnv, {
+      PGPORT: dbTunnelConfig.localPort,
+      PGHOST: dbTunnelConfig.localHost
+    })
+  }
+  return {
+    dbEnv: dbEnv,
+    dbTunnelConfig: dbTunnelConfig
+  }
+}
+
+exports.getConfigs = getConfigs
+
+function sshTunnel (db, dbTunnelConfig, timeout) {
+  return new Promise((resolve, reject) => {
+    // if necessary to tunnel, setup a tunnel
+    // see also https://github.com/heroku/heroku/blob/master/lib/heroku/helpers/heroku_postgresql.rb#L53-L80
+    let timer = setTimeout(() => reject('Establishing a secure tunnel timed out'), timeout)
+    if (db.bastionKey) {
+      tunnel(dbTunnelConfig, (err, tnl) => {
+        if (err) {
+          debug(err)
+          reject(`Unable to establish a secure tunnel to your database.`)
+        }
+        debug('Tunnel created')
+        clearTimeout(timer)
+        resolve(tnl)
+      })
+    } else {
+      clearTimeout(timer)
+      resolve()
+    }
+  })
+}
+
+exports.sshTunnel = sshTunnel

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,24 +2,7 @@
 
 const cli = require('heroku-cli-util')
 const debug = require('./debug')
-
-const getBastion = function (config, baseName) {
-  const sample = require('lodash.sample')
-  // If there are bastions, extract a host and a key
-  // otherwise, return an empty Object
-
-  // If there are bastions:
-  // * there should be one *_BASTION_KEY
-  // * pick one host from the comma-separated list in *_BASTIONS
-  // We assert that _BASTIONS and _BASTION_KEY always exist together
-  // If either is falsy, pretend neither exist
-
-  const bastionKey = config[`${baseName}_BASTION_KEY`]
-  const bastionHost = sample((config[`${baseName}_BASTIONS`] || '').split(','))
-  return (!(bastionKey && bastionHost))
-    ? {}
-    : {bastionHost, bastionKey}
-}
+const getBastion = require('./bastion').getBastion
 
 function getUrl (configVars) {
   let connstringVars = configVars.filter((cv) => (cv.endsWith('_URL')))

--- a/test/commands/pull.js
+++ b/test/commands/pull.js
@@ -8,35 +8,59 @@ const proxyquire = require('proxyquire')
 const expect = require('unexpected')
 const env = require('process').env
 
-const db = {
-  user: 'jeff',
-  password: 'pass',
-  database: 'mydb',
-  port: 5432,
-  host: 'herokai.com',
-  attachment: {
-    addon: {
-      name: 'postgres-1'
-    },
-    config_vars: ['DATABASE_URL'],
-    app: {name: 'myapp'}
-  }
-}
+let db
 
 const fetcher = () => ({
   database: () => db
 })
-const push = proxyquire('../../commands/pull', {
-  '../lib/fetcher': fetcher
-})[0]
 
-const pull = proxyquire('../../commands/pull', {
-  '../lib/fetcher': fetcher
-})[1]
+let tunnelStub
+let bastion
+let push
+let pull
 
 describe('pg', () => {
   beforeEach(() => {
     cli.mockConsole()
+
+    db = {
+      user: 'jeff',
+      password: 'pass',
+      database: 'mydb',
+      port: 5432,
+      host: 'herokai.com',
+      attachment: {
+        addon: {
+          name: 'postgres-1'
+        },
+        config_vars: ['DATABASE_URL'],
+        app: {name: 'myapp'}
+      }
+    }
+
+    tunnelStub = sinon.stub().callsArg(1)
+
+    bastion = proxyquire('../../lib/bastion', {
+      'tunnel-ssh': tunnelStub
+    })
+
+    push = proxyquire('../../commands/pull', {
+      '../lib/fetcher': fetcher,
+      '../lib/bastion': bastion
+    })[0]
+
+    pull = proxyquire('../../commands/pull', {
+      '../lib/fetcher': fetcher,
+      '../lib/bastion': bastion
+    })[1]
+
+    sinon.stub(Math, 'random', function () {
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    Math.random.restore()
   })
 
   describe('push', () => {
@@ -81,6 +105,34 @@ describe('pg', () => {
       .then(() => expect(cli.stderr, 'to equal', ''))
       .then(() => psql.exec.restore())
     }))
+
+    it('opens an SSH tunnel and runs pg_dump for bastion databases', sinon.test(() => {
+      db.bastionHost = 'bastion-host'
+      db.bastionKey = 'super-private-key'
+
+      let tunnelConf = {
+        username: 'bastion',
+        host: 'bastion-host',
+        privateKey: 'super-private-key',
+        dstHost: 'herokai.com',
+        dstPort: 5432,
+        localHost: '127.0.0.1',
+        localPort: 49152
+      }
+
+      let psql = require('../../lib/psql')
+      sinon.stub(psql, 'exec').returns(Promise.resolve(' empty \n-------\n t'))
+      let cp = sinon.mock(require('child_process'))
+      cp.expects('execSync').withExactArgs('env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5432  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb', {stdio: 'inherit'}).once()
+      return push.run({args: {source: 'localdb', target: 'postgres-1'}})
+      .then(() => cp.verify())
+      .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
+      .then(() => expect(cli.stderr, 'to equal', ''))
+      .then(() => expect(
+        tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
+      )
+      .then(() => psql.exec.restore())
+    }))
   })
 
   describe('pull', () => {
@@ -94,6 +146,35 @@ describe('pg', () => {
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n'))
       .then(() => expect(cli.stderr, 'to equal', ''))
+      .then(() => psql.exec.restore())
+    }))
+
+    it('opens an SSH tunnel and runs pg_dump for bastion databases', sinon.test(() => {
+      db.bastionHost = 'bastion-host'
+      db.bastionKey = 'super-private-key'
+
+      let tunnelConf = {
+        username: 'bastion',
+        host: 'bastion-host',
+        privateKey: 'super-private-key',
+        dstHost: 'herokai.com',
+        dstPort: 5432,
+        localHost: '127.0.0.1',
+        localPort: 49152
+      }
+
+      let psql = require('../../lib/psql')
+      sinon.stub(psql, 'exec')
+      let cp = sinon.mock(require('child_process'))
+      cp.expects('execSync').withExactArgs('createdb  -h localhost -p 5432  localdb', {stdio: 'inherit'}).once()
+      cp.expects('execSync').withExactArgs('env PGPASSWORD="pass" PGSSLMODE=prefer pg_dump --verbose -F c -Z 0 -U jeff -h herokai.com -p 5432  mydb | env pg_restore --verbose --no-acl --no-owner  -h localhost -p 5432 -d localdb', {stdio: 'inherit'}).once()
+      return pull.run({args: {source: 'postgres-1', target: 'localdb'}})
+      .then(() => cp.verify())
+      .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n'))
+      .then(() => expect(cli.stderr, 'to equal', ''))
+      .then(() => expect(
+        tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true)
+      )
       .then(() => psql.exec.restore())
     }))
   })

--- a/test/commands/pull.js
+++ b/test/commands/pull.js
@@ -19,6 +19,16 @@ let bastion
 let push
 let pull
 
+let opts = { encoding: 'utf8', shell: true, stdio: ['ignore', 'pipe', 'inherit'] }
+
+let stdoutHandler = function (key, func) {
+  func('result')
+}
+
+let exitHandler = function (key, func) {
+  func(0)
+}
+
 describe('pg', () => {
   beforeEach(() => {
     cli.mockConsole()
@@ -71,8 +81,18 @@ describe('pg', () => {
     it('pushes out a db', sinon.test(() => {
       let psql = require('../../lib/psql')
       sinon.stub(psql, 'exec').returns(Promise.resolve(' empty \n-------\n t'))
+
       let cp = sinon.mock(require('child_process'))
-      cp.expects('execSync').withExactArgs('env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5432  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb', {stdio: 'inherit'}).once()
+      let cmd = 'env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5432  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb'
+      cp.expects('spawn').withExactArgs(cmd, [], opts).once().returns(
+        {
+          stdout: {
+            on: stdoutHandler
+          },
+          on: exitHandler
+        }
+      )
+
       return push.run({args: {source: 'localdb', target: 'postgres-1'}})
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
@@ -84,7 +104,17 @@ describe('pg', () => {
       let psql = require('../../lib/psql')
       sinon.stub(psql, 'exec').returns(Promise.resolve(' empty \n-------\n t'))
       let cp = sinon.mock(require('child_process'))
-      cp.expects('execSync').withExactArgs('env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5433  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb', {stdio: 'inherit'}).once()
+      let cmd = 'env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5433  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb'
+
+      cp.expects('spawn').withExactArgs(cmd, [], opts).once().returns(
+        {
+          stdout: {
+            on: stdoutHandler
+          },
+          on: exitHandler
+        }
+      )
+
       return push.run({args: {source: 'postgres://localhost:5433/localdb', target: 'postgres-1'}})
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pushing postgres://localhost:5433/localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
@@ -98,7 +128,17 @@ describe('pg', () => {
       let psql = require('../../lib/psql')
       sinon.stub(psql, 'exec').returns(Promise.resolve(' empty \n-------\n t'))
       let cp = sinon.mock(require('child_process'))
-      cp.expects('execSync').withExactArgs('env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5433  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb', {stdio: 'inherit'}).once()
+
+      let cmd = 'env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5433  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb'
+      cp.expects('spawn').withExactArgs(cmd, [], opts).once().returns(
+        {
+          stdout: {
+            on: stdoutHandler
+          },
+          on: exitHandler
+        }
+      )
+
       return push.run({args: {source: 'localdb', target: 'postgres-1'}})
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
@@ -123,7 +163,16 @@ describe('pg', () => {
       let psql = require('../../lib/psql')
       sinon.stub(psql, 'exec').returns(Promise.resolve(' empty \n-------\n t'))
       let cp = sinon.mock(require('child_process'))
-      cp.expects('execSync').withExactArgs('env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5432  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb', {stdio: 'inherit'}).once()
+      let cmd = 'env PGSSLMODE=prefer pg_dump --verbose -F c -Z 0  -h localhost -p 5432  localdb | env PGPASSWORD="pass" pg_restore --verbose --no-acl --no-owner -U jeff -h herokai.com -p 5432 -d mydb'
+      cp.expects('spawn').withExactArgs(cmd, [], opts).once().returns(
+        {
+          stdout: {
+            on: stdoutHandler
+          },
+          on: exitHandler
+        }
+      )
+
       return push.run({args: {source: 'localdb', target: 'postgres-1'}})
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pushing localdb ---> postgres-1\nheroku-cli: Pushing complete.\n'))
@@ -141,7 +190,17 @@ describe('pg', () => {
       sinon.stub(psql, 'exec')
       let cp = sinon.mock(require('child_process'))
       cp.expects('execSync').withExactArgs('createdb  -h localhost -p 5432  localdb', {stdio: 'inherit'}).once()
-      cp.expects('execSync').withExactArgs('env PGPASSWORD="pass" PGSSLMODE=prefer pg_dump --verbose -F c -Z 0 -U jeff -h herokai.com -p 5432  mydb | env pg_restore --verbose --no-acl --no-owner  -h localhost -p 5432 -d localdb', {stdio: 'inherit'}).once()
+
+      let cmd = 'env PGPASSWORD="pass" PGSSLMODE=prefer pg_dump --verbose -F c -Z 0 -U jeff -h herokai.com -p 5432  mydb | env pg_restore --verbose --no-acl --no-owner  -h localhost -p 5432 -d localdb'
+      cp.expects('spawn').withExactArgs(cmd, [], opts).once().returns(
+        {
+          stdout: {
+            on: stdoutHandler
+          },
+          on: exitHandler
+        }
+      )
+
       return pull.run({args: {source: 'postgres-1', target: 'localdb'}})
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n'))
@@ -167,7 +226,17 @@ describe('pg', () => {
       sinon.stub(psql, 'exec')
       let cp = sinon.mock(require('child_process'))
       cp.expects('execSync').withExactArgs('createdb  -h localhost -p 5432  localdb', {stdio: 'inherit'}).once()
-      cp.expects('execSync').withExactArgs('env PGPASSWORD="pass" PGSSLMODE=prefer pg_dump --verbose -F c -Z 0 -U jeff -h herokai.com -p 5432  mydb | env pg_restore --verbose --no-acl --no-owner  -h localhost -p 5432 -d localdb', {stdio: 'inherit'}).once()
+
+      let cmd = 'env PGPASSWORD="pass" PGSSLMODE=prefer pg_dump --verbose -F c -Z 0 -U jeff -h herokai.com -p 5432  mydb | env pg_restore --verbose --no-acl --no-owner  -h localhost -p 5432 -d localdb'
+      cp.expects('spawn').withExactArgs(cmd, [], opts).once().returns(
+        {
+          stdout: {
+            on: stdoutHandler
+          },
+          on: exitHandler
+        }
+      )
+
       return pull.run({args: {source: 'postgres-1', target: 'localdb'}})
       .then(() => cp.verify())
       .then(() => expect(cli.stdout, 'to equal', 'heroku-cli: Pulling postgres-1 ---> localdb\nheroku-cli: Pulling complete.\n'))

--- a/test/lib/psql.js
+++ b/test/lib/psql.js
@@ -1,6 +1,6 @@
 'use strict'
 
-/* global describe it */
+/* global describe it beforeEach afterEach */
 
 const sinon = require('sinon')
 const expect = require('unexpected')
@@ -26,11 +26,25 @@ const bastionDb = {
 
 const proxyquire = require('proxyquire')
 var tunnelStub = sinon.stub().callsArg(1)
-const psql = proxyquire('../../lib/psql', {
+
+const bastion = proxyquire('../../lib/bastion', {
   'tunnel-ssh': tunnelStub
+})
+const psql = proxyquire('../../lib/psql', {
+  './bastion': bastion
 })
 
 describe('psql', () => {
+  beforeEach(() => {
+    sinon.stub(Math, 'random', function () {
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    Math.random.restore()
+  })
+
   describe('exec', () => {
     it('runs psql', sinon.test(() => {
       let cp = sinon.mock(require('child_process'))
@@ -61,9 +75,6 @@ describe('psql', () => {
     }))
     it('opens an SSH tunnel and runs psql for bastion databases', sinon.test(() => {
       let cp = sinon.mock(require('child_process'))
-      sinon.stub(Math, 'random', function () {
-        return 0
-      })
       let tunnelConf = {
         username: 'bastion',
         host: 'bastion-host',


### PR DESCRIPTION
@dickeyxxx was getting really close, but it still hangs.  See my debugging notes here, it appears that the tunnel is getting set up correctly, but that the command itself hangs for unknown reasons.  If you want the command we shell out and run it manually during that wait period it does return the expected output, not sure why it does not work through exec yet while psql seems to have no issues (although psql uses spawn and sets things up via environment variables passed down to spawn)

[1ca782669f9fa62a1c35d472b142325f55bda222](https://github.com/heroku/heroku-pg/commit/1ca782669f9fa62a1c35d472b142325f55bda222#diff-caacc9db9d4fdff25c7eacfa9b8d4fdcR94)