### PR TITLE
Prefer target than source as an attachment

### DIFF
--- a/commands/copy.js
+++ b/commands/copy.js
@@ -49,7 +49,7 @@ Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.col
   let copy
   let attachment
   yield cli.action(`Starting copy of ${cli.color.yellow(source.name)} to ${cli.color.yellow(target.name)}`, co(function * () {
-    attachment = source.attachment || target.attachment
+    attachment = target.attachment || source.attachment
     if (!attachment) throw new Error('Heroku PostgreSQL database must be source or target')
     copy = yield heroku.post(`/client/v11/databases/${attachment.addon.name}/transfers`, {
       body: {


### PR DESCRIPTION
Use `target` as an attachment if possible. This is important because we're doing the "reset database" part on the api side ([here](https://github.com/heroku/yobuko/blob/cc1f7d9cda082f9d337389b6e6c58dd2da795680/web/client/v11.rb#L287-L296) and [here](https://github.com/heroku/shogun/blob/01f83d4100235d1c92d9072a4138dae61fd15920/lib/web/client_api/v11.rb#L473-L496)), and it is important to know that target resource is owned by us.
This is causing the issue that the target db is not reset before the restore.

Previous implementation:
https://github.com/heroku/legacy-cli/blob/d7e9718079b9936ffd264529bdd03a6734fd64cc/lib/heroku/command/pg_backups.rb#L30