### PR TITLE
Show load properly for pg:diagnose

### DIFF
--- a/commands/diagnose.js
+++ b/commands/diagnose.js
@@ -2,6 +2,7 @@
 
 const cli = require('heroku-cli-util')
 const co = require('co')
+const capitalize = require('lodash.capitalize')
 const PGDIAGNOSE_HOST = process.env.PGDIAGNOSE_URL || 'https://pgdiagnose.herokai.com'
 
 function * run (context, heroku) {
@@ -34,20 +35,27 @@ function * run (context, heroku) {
 available for one month after creation on ${report.created_at}
 `)
     let display = checks => {
-      for (let check of checks) {
-        cli.log(cli.color[check.status](`${check.status.toUpperCase()}: ${check.name}`))
-        if (check.status === 'green') continue
+      checks.forEach((check) => {
+        let color = cli.color[check.status] || ((txt) => txt)
+        cli.log(color(`${check.status.toUpperCase()}: ${check.name}`))
+
+        if (check.status === 'green') return
         if (!check.results) return
+
         if (Array.isArray(check.results)) {
+          if (!check.results.length) return
+
           let keys = Object.keys(check.results[0])
           cli.table(check.results, {
-            columns: keys.map(key => ({key}))
+            columns: keys.map(key => ({label: capitalize(key), key: key}))
           })
         } else {
+          if (!Object.keys(check.results).length) return
+
           let key = Object.keys(check.results)[0]
-          cli.log(`${key} ${check.results[key]}`)
+          cli.log(`${key.split('_').map((s) => capitalize(s)).join(' ')} ${check.results[key]}`)
         }
-      }
+      })
     }
     display(report.checks.filter(c => c.status === 'red'))
     display(report.checks.filter(c => c.status === 'yellow'))

--- a/commands/diagnose.js
+++ b/commands/diagnose.js
@@ -37,14 +37,15 @@ available for one month after creation on ${report.created_at}
       for (let check of checks) {
         cli.log(cli.color[check.status](`${check.status.toUpperCase()}: ${check.name}`))
         if (check.status === 'green') continue
-        if (!check.results || !check.results.length) return
-        if (Array.isArray(check.results[0])) {
-          cli.log(`  ${check.results[0].join(' ')}`)
-        } else {
+        if (!check.results) return
+        if (Array.isArray(check.results)) {
           let keys = Object.keys(check.results[0])
           cli.table(check.results, {
             columns: keys.map(key => ({key}))
           })
+        } else {
+          let key = Object.keys(check.results)[0]
+          cli.log(`${key} ${check.results[key]}`)
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "filesize": "3.3.0",
     "heroku-cli-addons": "1.2.1",
     "heroku-cli-util": "6.0.16",
+    "lodash.capitalize": "4.2.1",
     "lodash.flatten": "4.4.0",
     "lodash.sample": "4.2.1",
     "lodash.sortby": "4.7.0",

--- a/test/commands/diagnose.js
+++ b/test/commands/diagnose.js
@@ -59,6 +59,11 @@ describe('pg:diagnose', () => {
           name: 'Connection count',
           status: 'red',
           results: [{count: 1}]
+        },
+        {
+          name: 'Load',
+          status: 'red',
+          results: {load: 100}
         }
       ]
     })
@@ -70,6 +75,8 @@ RED: Connection count
 count
 ─────
 1
+RED: Load
+load 100
 `))
   })
 
@@ -84,6 +91,11 @@ count
           name: 'Connection count',
           status: 'red',
           results: [{count: 1}]
+        },
+        {
+          name: 'Load',
+          status: 'red',
+          results: {load: 100}
         }
       ]
     })
@@ -95,6 +107,8 @@ RED: Connection count
 count
 ─────
 1
+RED: Load
+load 100
 `))
   })
 })

--- a/test/commands/diagnose.js
+++ b/test/commands/diagnose.js
@@ -72,11 +72,11 @@ describe('pg:diagnose', () => {
 available for one month after creation on 101
 
 RED: Connection count
-count
+Count
 ─────
 1
 RED: Load
-load 100
+Load 100
 `))
   })
 
@@ -104,11 +104,109 @@ load 100
 available for one month after creation on 101
 
 RED: Connection count
-count
+Count
 ─────
 1
 RED: Load
-load 100
+Load 100
+`))
+  })
+
+  it('displays an existing report with empty results', () => {
+    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+      id: '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c',
+      app: 'myapp',
+      database: 'postgres-1',
+      created_at: '101',
+      checks: [
+        {
+          name: 'Connection count',
+          status: 'red',
+          results: []
+        },
+        {
+          name: 'Load',
+          status: 'red',
+          results: {}
+        }
+      ]
+    })
+    return cmd.run({app: 'myapp', args: {'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c'}})
+    .then(() => expect(cli.stdout, 'to equal', `Report 697c8bd7-dbba-4f2d-83b6-789c58cc3a9c for myapp::postgres-1
+available for one month after creation on 101
+
+RED: Connection count
+RED: Load
+`))
+  })
+
+  it('roughly conforms with Ruby output', () => {
+    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+      'id': 'abc123',
+      'app': 'appname',
+      'created_at': '2014-06-24 01:26:11.941197+00',
+      'database': 'dbcolor',
+      'checks': [
+        {'name': 'Hit Rate', 'status': 'green', 'results': null},
+        {'name': 'Connection Count', 'status': 'red', 'results': [{'count': 150}]},
+        {
+          'name': 'list',
+          'status': 'yellow',
+          'results': [
+            {'thing': 'one'},
+            {'thing': 'two'}
+          ]
+        },
+        {
+          'name': 'Load',
+          'status': 'skipped',
+          'results': {
+            'error': 'Load check not supported on this plan'
+          }
+        }
+      ]
+    })
+    return cmd.run({app: 'myapp', args: {'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c'}})
+    .then(() => expect(cli.stdout, 'to equal', `Report abc123 for appname::dbcolor
+available for one month after creation on 2014-06-24 01:26:11.941197+00
+
+RED: Connection Count
+Count
+─────
+150
+YELLOW: list
+Thing
+─────
+one
+two
+GREEN: Hit Rate
+SKIPPED: Load
+Error Load check not supported on this plan
+`))
+  })
+
+  it('converts underscores to spaces', () => {
+    diagnose.get('/reports/697c8bd7-dbba-4f2d-83b6-789c58cc3a9c').reply(200, {
+      'id': 'abc123',
+      'app': 'appname',
+      'created_at': '2014-06-24 01:26:11.941197+00',
+      'database': 'dbcolor',
+      'checks': [
+        {
+          'name': 'Load',
+          'status': 'skipped',
+          'results': {
+            'error_thing': 'Load check not supported on this plan'
+          }
+        }
+      ]
+    })
+    return cmd.run({app: 'myapp', args: {'DATABASE|REPORT_ID': '697c8bd7-dbba-4f2d-83b6-789c58cc3a9c'}})
+    .then(() => expect(cli.stdout, 'to equal', `Report abc123 for appname::dbcolor
+available for one month after creation on 2014-06-24 01:26:11.941197+00
+
+SKIPPED: Load
+Error Thing Load check not supported on this plan
 `))
   })
 })


### PR DESCRIPTION
Seems like showing the certain value (only `Load`, I believe) that you get from pgdiagnose is not working properly. Here is expected response json examples (it's in the test as well):

```
  {
    "name": "Hit Rate",
    "status": "red",
    "results": [
      {
        "name": "overall index hit rate",
        "ratio": 0.9861242393582039
      },
      {
        "name": "overall cache hit rate",
        "ratio": 0.9637371701579502
      }
    ]
  },
  {
    "name": "Blocking Queries",
    "status": "green",
    "results": null
  },
  {
    "name": "Sequences",
    "status": "green",
    "results": null
  },
  {
    "name": "Load",
    "status": "red",
    "results": {
      "load": "15.36"
    }
  }
```

Previously, in Ruby version, [it was taken care of this way](https://github.com/heroku/legacy-cli/blob/d7e9718079b9936ffd264529bdd03a6734fd64cc/lib/heroku/helpers/pg_diagnose.rb#L92-L100), which wasn't converted to Node properly.

Ideally, it'll be like;

```
RED: Load
Load 100
```

instead of;

```
RED: Load
load 100
```

but seems like Node doesn't have any easy way to capitalize the first letter so...

Can you please review @ransombriggs ? Thanks!