### PR TITLE
Add relevant documentation for pg:pull

### DIFF
--- a/commands/pull.js
+++ b/commands/pull.js
@@ -188,10 +188,10 @@ TARGET will be created locally if it's a database name or remotely if it's a ful
 Examples:
 
   # pull Heroku DB named postgresql-swimmingly-100 into local DB mylocaldb
-  $ heroku pg:push postgresql-swimmingly-100 mylocaldb
+  $ heroku pg:pull HEROKU_POSTGRESQL_MAGENTA mylocaldb --app sushi
 
   # pull Heroku DB named postgresql-swimmingly-100 into remote DB at postgres://myhost/mydb
-  $ heroku pg:push postgresql-swimmingly-100 postgres://myhost/mydb
+  $ heroku pg:pull HEROKU_POSTGRESQL_MAGENTA postgres://myhost/mydb --app sushi
 `,
     run: cli.command({preauth: true}, co.wrap(pull))
   }, cmd)

--- a/commands/pull.js
+++ b/commands/pull.js
@@ -188,10 +188,10 @@ TARGET will be created locally if it's a database name or remotely if it's a ful
 Examples:
 
   # pull Heroku DB named postgresql-swimmingly-100 into local DB mylocaldb
-  $ heroku pg:pull HEROKU_POSTGRESQL_MAGENTA mylocaldb --app sushi
+  $ heroku pg:pull postgresql-swimmingly-100 mylocaldb --app sushi
 
   # pull Heroku DB named postgresql-swimmingly-100 into remote DB at postgres://myhost/mydb
-  $ heroku pg:pull HEROKU_POSTGRESQL_MAGENTA postgres://myhost/mydb --app sushi
+  $ heroku pg:pull postgresql-swimmingly-100 postgres://myhost/mydb --app sushi
 `,
     run: cli.command({preauth: true}, co.wrap(pull))
   }, cmd)


### PR DESCRIPTION
The examples in the documentation for `pg:pull` were examples for `pg:push`.

I should be clear that I am assuming that the explicit URI in the second example is valid. Please test this before merging this, until you already know that it works.