### PR TITLE
Fix env cascading when invoking psql

### DIFF
--- a/lib/bastion.js
+++ b/lib/bastion.js
@@ -24,15 +24,25 @@ const getBastion = function (config, baseName) {
 exports.getBastion = getBastion
 
 const env = function (db) {
-  return Object.assign({}, process.env, {
-    PGAPPNAME: 'psql non-interactive',
-    PGSSLMODE: db.hostname === 'localhost' ? 'prefer' : 'require',
-    PGUSER: db.user || '',
-    PGPASSWORD: db.password,
-    PGDATABASE: db.database,
-    PGPORT: db.port || 5432,
-    PGHOST: db.host
+  let baseEnv = Object.assign({
+    PGAPPNAME: 'psql non-interactive'
+  }, process.env, {
+    PGSSLMODE: (!db.hostname || db.hostname === 'localhost') ? 'prefer' : 'require'
   })
+  let mapping = {
+    PGUSER: 'user',
+    PGPASSWORD: 'password',
+    PGDATABASE: 'database',
+    PGPORT: 'port',
+    PGHOST: 'host'
+  }
+  Object.keys(mapping).forEach((envVar) => {
+    let val = db[mapping[envVar]]
+    if (val) {
+      baseEnv[envVar] = val
+    }
+  })
+  return baseEnv
 }
 
 exports.env = env


### PR DESCRIPTION
Currently we override most PG* environment variables, but there's no
good reason for this--if the user has set something, we should not
require them to override this via the URL.

With this change, they still *can* if they need to do so explicitly,
but we shouldn't clobber valid various from the environment with empty
ones.

We keep PGSSLMODE as a setting users cannot override (to avoid
unencrypted connections to remote databases), but account for unset
hosts (which defaults to a local connection).

Fixes #92
