### PR TITLE
Address the edge case of async provisioning

### DIFF
--- a/commands/info.js
+++ b/commands/info.js
@@ -5,9 +5,14 @@ const cli = require('heroku-cli-util')
 const util = require('../lib/util')
 
 function displayDB (db, app) {
-  cli.styledHeader(db.configVars.map(c => cli.color.configVar(c)).join(', '))
+  if (db.addon.attachment_names) {
+    cli.styledHeader(db.addon.attachment_names.map(c => cli.color.configVar(c + '_URL')).join(', '))
+  } else {
+    cli.styledHeader(db.configVars.map(c => cli.color.configVar(c)).join(', '))
+  }
+
   if (db.addon.app.name !== app) {
-    db.db.info.push({name: 'Billing App', values: [db.addon.app.name]})
+    db.db.info.push({name: 'Billing App', values: [cli.color.cyan(db.addon.app.name)]})
   }
   db.db.info.push({name: 'Add-on', values: [cli.color.addon(db.addon.name)]})
   let info = db.db.info.reduce((info, i) => {
@@ -56,7 +61,7 @@ function * run (context, heroku) {
         path: `/client/v11/databases/${addon.name}`
       }).catch(err => {
         if (err.statusCode !== 404) throw err
-        cli.warn(`${cli.color.addon(addon.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku pg:wait')} to wait until the db is provisioned.`)
+        cli.warn(`${cli.color.addon(addon.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
       })
     }
   })

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -66,6 +66,7 @@ module.exports = heroku => {
       }
     }
 
+    // case for multiple attachments with passedDb
     let first = matches[0]
 
     // case for 422 where there are ambiguous attachments that are equivalent
@@ -101,13 +102,32 @@ module.exports = heroku => {
     return attachments.filter(a => a.addon.plan.name.startsWith('heroku-postgresql'))
   }
 
+  function * getAttachmentNamesByAddons (attachments) {
+    let results = {}
+    attachments.forEach(function (a) {
+      let attachmentNames = results[a.addon.id] || []
+      attachmentNames = attachmentNames.concat(a.name)
+      results[a.addon.id] = attachmentNames
+    })
+
+    return results
+  }
+
   function * all (app) {
     const uniqby = require('lodash.uniqby')
 
     debug(`fetching all DBs on ${app}`)
 
-    let addons = (yield allAttachments(app)).map(a => a.addon)
+    let attachments = yield allAttachments(app)
+    let addons = attachments.map(a => a.addon)
+
+    // Get the list of config vars per addon here and add to each addon
+    let attachmentNamesByAddons = yield getAttachmentNamesByAddons(attachments)
     addons = uniqby(addons, 'id')
+    addons = addons.map(function (a) {
+      a.attachment_names = attachmentNamesByAddons[a.id]
+      return a
+    })
 
     return addons
   }

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -102,7 +102,7 @@ module.exports = heroku => {
     return attachments.filter(a => a.addon.plan.name.startsWith('heroku-postgresql'))
   }
 
-  function * getAttachmentNamesByAddon (attachments) {
+  function getAttachmentNamesByAddon (attachments) {
     return attachments.reduce((results, a) => {
       results[a.addon.id] = (results[a.addon.id] || []).concat(a.name)
       return results
@@ -118,7 +118,7 @@ module.exports = heroku => {
     let addons = attachments.map(a => a.addon)
 
     // Get the list of attachment names per addon here and add to each addon obj
-    let attachmentNamesByAddon = yield getAttachmentNamesByAddon(attachments)
+    let attachmentNamesByAddon = getAttachmentNamesByAddon(attachments)
     addons = uniqby(addons, 'id')
     addons.forEach(addon => {
       addon.attachment_names = attachmentNamesByAddon[addon.id]

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -102,15 +102,11 @@ module.exports = heroku => {
     return attachments.filter(a => a.addon.plan.name.startsWith('heroku-postgresql'))
   }
 
-  function * getAttachmentNamesByAddons (attachments) {
-    let results = {}
-    attachments.forEach(function (a) {
-      let attachmentNames = results[a.addon.id] || []
-      attachmentNames = attachmentNames.concat(a.name)
-      results[a.addon.id] = attachmentNames
-    })
-
-    return results
+  function * getAttachmentNamesByAddon (attachments) {
+    return attachments.reduce((results, a) => {
+      results[a.addon.id] = (results[a.addon.id] || []).concat(a.name)
+      return results
+    }, {})
   }
 
   function * all (app) {
@@ -121,12 +117,11 @@ module.exports = heroku => {
     let attachments = yield allAttachments(app)
     let addons = attachments.map(a => a.addon)
 
-    // Get the list of config vars per addon here and add to each addon
-    let attachmentNamesByAddons = yield getAttachmentNamesByAddons(attachments)
+    // Get the list of attachment names per addon here and add to each addon obj
+    let attachmentNamesByAddon = yield getAttachmentNamesByAddon(attachments)
     addons = uniqby(addons, 'id')
-    addons = addons.map(function (a) {
-      a.attachment_names = attachmentNamesByAddons[a.id]
-      return a
+    addons.forEach(addon => {
+      addon.attachment_names = attachmentNamesByAddon[addon.id]
     })
 
     return addons

--- a/test/commands/info.js
+++ b/test/commands/info.js
@@ -93,6 +93,32 @@ Add-on:    postgres-2
       .then(() => expect(cli.stderr, 'to equal', ''))
     })
 
+    it('shows postgres info using attachment names', () => {
+      all = [
+        {id: 1, name: 'postgres-1', plan, app: {name: 'myapp2'}, attachment_names: ['DATABASE', 'ATTACHMENT_NAME']},
+        {id: 2, name: 'postgres-2', plan, app: {name: 'myapp'}, attachment_names: ['HEROKU_POSTGRESQL_PURPLE']}
+      ]
+
+      api.get('/apps/myapp/config-vars').reply(200, config)
+      pg
+      .get('/client/v11/databases/postgres-1').reply(200, dbA)
+      .get('/client/v11/databases/postgres-2').reply(200, dbB)
+
+      return cmd.run({app: 'myapp', args: {}})
+      .then(() => expect(cli.stdout, 'to equal', `=== DATABASE_URL, ATTACHMENT_NAME_URL
+Plan:        Hobby-dev
+Following:   HEROKU_POSTGRESQL_COBALT
+Billing App: myapp2
+Add-on:      postgres-1
+
+=== HEROKU_POSTGRESQL_PURPLE_URL
+Plan:      Hobby-dev
+Following: ec2-55-111-111-1.compute-1.amazonaws.com:5432/dxxxxxxxxxxxx
+Add-on:    postgres-2
+
+`))
+    })
+
     it('shows postgres info for single database when arg sent in', () => {
       addon = addons[1]
       api.get('/apps/myapp/config-vars').reply(200, config)
@@ -126,7 +152,7 @@ Add-on:    postgres-2
 
 `))
       .then(() => expect(cli.stderr, 'to equal', ` ▸    postgres-1 is not yet provisioned.
- ▸    Run heroku pg:wait to wait until the db is provisioned.
+ ▸    Run heroku addons:wait to wait until the db is provisioned.
 `))
     })
   })

--- a/test/lib/fetcher.js
+++ b/test/lib/fetcher.js
@@ -394,8 +394,9 @@ describe('fetcher', () => {
     it('returns all addons attached to app', () => {
       let plan = {name: 'heroku-postgresql:hobby-dev'}
       let attachments = [
-        {addon: {id: 100, name: 'postgres-1', plan, config_vars: ['DATABASE_URL', 'HEROKU_POSTGRESQL_PINK_URL']}},
-        {addon: {id: 101, name: 'postgres-2', plan, config_vars: ['HEROKU_POSTGRESQL_BRONZE_URL']}}
+        {addon: {id: 100, name: 'postgres-1', plan}, name: 'DATABASE'},
+        {addon: {id: 100, name: 'postgres-1', plan}, name: 'HEROKU_POSTGRESQL_PINK'},
+        {addon: {id: 101, name: 'postgres-2', plan}, name: 'HEROKU_POSTGRESQL_BRONZE'}
       ]
       api.get('/apps/myapp/addon-attachments').reply(200, attachments)
 
@@ -403,6 +404,7 @@ describe('fetcher', () => {
       .then(addons => {
         expect(addons[0], 'to satisfy', {name: 'postgres-1'})
         expect(addons[1], 'to satisfy', {name: 'postgres-2'})
+        expect(addons[0], 'to satisfy', {attachment_names: ['DATABASE', 'HEROKU_POSTGRESQL_PINK']})
         expect(addons.length, 'to equal', 2)
       })
     })


### PR DESCRIPTION
Right now, after the Postgres started provisioning, `heroku pg` command will return following over time:

**0. Provision**

```
$ heroku addons:create heroku-postgresql:standard-0 -a keiko-heroku-pg-test
Creating heroku-postgresql:standard-0 on ⬢ keiko-heroku-pg-test... $50/month
The database should be available in 3-5 minutes.
! CAUTION: The database will be empty. If upgrading, you can transfer
!          data from another database with pg:copy.
Use `heroku pg:wait` to track status.
postgresql-acute-75514 is being created in the background. The app will restart when complete...
Use heroku addons:info postgresql-acute-75514 to check creation progress
Use heroku addons:docs heroku-postgresql to view documentation
```

**1. Right after the provision and shogun is still returning 404**

```
$ heroku pg -a keiko-heroku-pg-test
 ▸    postgresql-acute-75514 is not yet provisioned.
 ▸    Run heroku pg:wait to wait until the db is provisioned.
```

**2. Provisioning is ongoing and shogun is not returning 404 anymore**

```
$ heroku pg -a keiko-heroku-pg-test
=== 
Plan:               Standard 0
Status:             Preparing
Fork/Follow:        Temporarily Unavailable
Rollback:           Temporarily Unavailable
Created:            2017-03-25 00:33 UTC
Region:             us
Maintenance:        not required
Maintenance window: Mondays 19:00 to 23:00 UTC
Add-on:             postgresql-acute-75514
```

**3. Provision has finished**

```
$ heroku pg -a keiko-heroku-pg-test
=== DATABASE_URL
Plan:               Standard 0
Status:             Available
Fork/Follow:        Available
Rollback:           earliest from 2017-03-25 00:35 UTC
Created:            2017-03-25 00:33 UTC
Region:             us
Maintenance:        not required
Maintenance window: Mondays 19:00 to 23:00 UTC
Add-on:             postgresql-acute-75514
```

This is confusing as the users will see the result with empty header with step 2. With this PR, instead of using config var approach and use the attachment names to show the header.

NOTE: I tried to implement this with `heroku pg:info some-specific-db` but it gets too complicated and kinda gave up. I'd like to hear if there is any way to improve this part as well.