### PR TITLE
Move all commands to use add-on uuids instead of names

### DIFF
--- a/commands/backups/capture.js
+++ b/commands/backups/capture.js
@@ -14,7 +14,7 @@ function * run (context, heroku) {
 
   let backup
   yield cli.action(`Starting backup of ${cli.color.addon(db.name)}`, co(function * () {
-    backup = yield heroku.post(`/client/v11/databases/${db.name}/backups`, {host: host(db)})
+    backup = yield heroku.post(`/client/v11/databases/${db.id}/backups`, {host: host(db)})
   }))
   cli.log(`
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.

--- a/commands/backups/restore.js
+++ b/commands/backups/restore.js
@@ -54,7 +54,7 @@ function * run (context, heroku) {
   yield cli.confirmApp(app, flags.confirm)
   let restore
   yield cli.action(`Starting restore of ${cli.color.cyan(backupName)} to ${cli.color.addon(db.name)}`, co(function * () {
-    restore = yield heroku.post(`/client/v11/databases/${db.name}/restores`, {
+    restore = yield heroku.post(`/client/v11/databases/${db.id}/restores`, {
       body: {backup_url: backupURL},
       host: host(db)
     })

--- a/commands/backups/schedule.js
+++ b/commands/backups/schedule.js
@@ -44,7 +44,7 @@ function * run (context, heroku) {
   yield cli.action(`Scheduling automatic daily backups of ${cli.color.addon(db.name)} at ${at}`, co(function * () {
     schedule.schedule_name = util.getUrl(attachment.config_vars)
 
-    yield heroku.post(`/client/v11/databases/${db.name}/transfer-schedules`, {
+    yield heroku.post(`/client/v11/databases/${db.id}/transfer-schedules`, {
       body: schedule,
       host: host(db)
     })

--- a/commands/backups/schedules.js
+++ b/commands/backups/schedules.js
@@ -9,7 +9,7 @@ function * run (context, heroku) {
   const {app} = context
 
   let db = yield fetcher.arbitraryAppDB(app)
-  let schedules = yield heroku.get(`/client/v11/databases/${db.name}/transfer-schedules`, {host: host(db)})
+  let schedules = yield heroku.get(`/client/v11/databases/${db.id}/transfer-schedules`, {host: host(db)})
 
   if (!schedules.length) {
     throw new Error(`No backup schedules found on ${cli.color.app(app)}

--- a/commands/backups/unschedule.js
+++ b/commands/backups/unschedule.js
@@ -12,7 +12,7 @@ function * run (context, heroku) {
 
   if (!args.database) {
     let appDB = yield fetcher.arbitraryAppDB(app)
-    let schedules = yield heroku.get(`/client/v11/databases/${appDB.name}/transfer-schedules`, {host: host(appDB)})
+    let schedules = yield heroku.get(`/client/v11/databases/${appDB.id}/transfer-schedules`, {host: host(appDB)})
     if (!schedules.length) throw new Error(`No schedules on ${cli.color.app(app)}`)
     if (schedules.length > 1) {
       throw new Error(`Specify schedule on ${cli.color.app(app)}. Existing schedules: ${schedules.map(s => cli.color.configVar(s.name)).join(', ')}`)
@@ -22,10 +22,10 @@ function * run (context, heroku) {
 
   yield cli.action(`Unscheduling ${cli.color.configVar(db)} daily backups`, co(function * () {
     let addon = yield fetcher.addon(app, db)
-    let schedules = yield heroku.get(`/client/v11/databases/${addon.name}/transfer-schedules`, {host: host(addon)})
+    let schedules = yield heroku.get(`/client/v11/databases/${addon.id}/transfer-schedules`, {host: host(addon)})
     let schedule = schedules.find(s => s.name.match(new RegExp(db, 'i')))
     if (!schedule) throw new Error(`No daily backups found for ${cli.color.addon(addon.name)}`)
-    yield heroku.delete(`/client/v11/databases/${addon.name}/transfer-schedules/${schedule.uuid}`, {
+    yield heroku.delete(`/client/v11/databases/${addon.id}/transfer-schedules/${schedule.uuid}`, {
       host: host(addon)
     })
   }))

--- a/commands/copy.js
+++ b/commands/copy.js
@@ -51,7 +51,7 @@ Data from ${cli.color.yellow(source.name)} will then be transferred to ${cli.col
   yield cli.action(`Starting copy of ${cli.color.yellow(source.name)} to ${cli.color.yellow(target.name)}`, co(function * () {
     attachment = target.attachment || source.attachment
     if (!attachment) throw new Error('Heroku PostgreSQL database must be source or target')
-    copy = yield heroku.post(`/client/v11/databases/${attachment.addon.name}/transfers`, {
+    copy = yield heroku.post(`/client/v11/databases/${attachment.addon.id}/transfers`, {
       body: {
         from_name: source.name,
         from_url: source.url,

--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -20,7 +20,7 @@ Connection URL:
     const host = require('../lib/host')
     let db = yield fetcher.addon(app, args.database)
     yield cli.action(`Resetting credentials on ${cli.color.addon(db.name)}`, co(function * () {
-      yield heroku.post(`/client/v11/databases/${db.name}/credentials_rotation`, {host: host(db)})
+      yield heroku.post(`/client/v11/databases/${db.id}/credentials_rotation`, {host: host(db)})
     }))
   })
 

--- a/commands/diagnose.js
+++ b/commands/diagnose.js
@@ -22,7 +22,7 @@ function * run (context, heroku) {
       database: util.getUrl(db.config_vars)
     }
     if (!util.starterPlan(db)) {
-      params.metrics = yield heroku.get(`/client/v11/databases/${db.name}/metrics`, {host: host(db)})
+      params.metrics = yield heroku.get(`/client/v11/databases/${db.id}/metrics`, {host: host(db)})
     }
     return yield heroku.post('/reports', {
       host: PGDIAGNOSE_HOST,

--- a/commands/info.js
+++ b/commands/info.js
@@ -58,7 +58,7 @@ function * run (context, heroku) {
       db: heroku.request({
         host: host(addon),
         method: 'get',
-        path: `/client/v11/databases/${addon.name}`
+        path: `/client/v11/databases/${addon.id}`
       }).catch(err => {
         if (err.statusCode !== 404) throw err
         cli.warn(`${cli.color.addon(addon.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)

--- a/commands/killall.js
+++ b/commands/killall.js
@@ -9,7 +9,7 @@ function * run (context, heroku) {
 
   yield cli.action('Terminating connections', co(function * () {
     const db = yield fetcher.addon(context.app, context.args.database)
-    yield heroku.post(`/client/v11/databases/${db.name}/connection_reset`, {host: host(db)})
+    yield heroku.post(`/client/v11/databases/${db.id}/connection_reset`, {host: host(db)})
   }))
 }
 

--- a/commands/links/create.js
+++ b/commands/links/create.js
@@ -21,7 +21,7 @@ function * run (context, heroku) {
   ]
 
   yield cli.action(`Adding link from ${cli.color.addon(target.name)} to ${cli.color.addon(db.name)}`, co(function * () {
-    let link = yield heroku.post(`/client/v11/databases/${db.name}/links`, {
+    let link = yield heroku.post(`/client/v11/databases/${db.id}/links`, {
       body: {
         target: target.name,
         as: flags.as

--- a/commands/links/destroy.js
+++ b/commands/links/destroy.js
@@ -16,7 +16,7 @@ This will delete ${cli.color.cyan(args.link)} along with the tables and views cr
 This may have adverse effects for software written against the ${cli.color.cyan(args.link)} schema.
 `)
   yield cli.action(`Destroying link ${cli.color.cyan(args.link)} from ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.delete(`/client/v11/databases/${db.name}/links/${encodeURIComponent(args.link)}`, {host: host(db)})
+    yield heroku.delete(`/client/v11/databases/${db.id}/links/${encodeURIComponent(args.link)}`, {host: host(db)})
   }))
 }
 

--- a/commands/links/index.js
+++ b/commands/links/index.js
@@ -15,7 +15,7 @@ function * run (context, heroku) {
   if (!dbs.length) throw new Error(`No databases on ${cli.color.app(app)}`)
 
   dbs = yield dbs.map(db => {
-    db.links = heroku.get(`/client/v11/databases/${db.name}/links`, {host: host(db)})
+    db.links = heroku.get(`/client/v11/databases/${db.id}/links`, {host: host(db)})
     return db
   })
 

--- a/commands/maintenance/index.js
+++ b/commands/maintenance/index.js
@@ -11,7 +11,7 @@ function * run (context, heroku) {
   const db = yield fetcher.addon(app, args.database)
 
   if (util.starterPlan(db)) throw new Error('pg:maintenance is only available for production databases')
-  let info = yield heroku.get(`/client/v11/databases/${db.name}/maintenance`, {host: host(db)})
+  let info = yield heroku.get(`/client/v11/databases/${db.id}/maintenance`, {host: host(db)})
   cli.log(info.message)
 }
 

--- a/commands/maintenance/run.js
+++ b/commands/maintenance/run.js
@@ -16,7 +16,7 @@ function * run (context, heroku) {
       let appInfo = yield heroku.get(`/apps/${app}`)
       if (!appInfo.maintenance) throw new Error('Application must be in maintenance mode or run with --force')
     }
-    let response = yield heroku.post(`/client/v11/databases/${db.name}/maintenance`, {host: host(db)})
+    let response = yield heroku.post(`/client/v11/databases/${db.id}/maintenance`, {host: host(db)})
     cli.action.done(response.message || 'done')
   }))
 }

--- a/commands/maintenance/window.js
+++ b/commands/maintenance/window.js
@@ -15,7 +15,7 @@ function * run (context, heroku) {
   if (!args.window.match(/^[A-Za-z]{2,10} \d\d?:[03]0$/)) throw new Error('Window must be "Day HH:MM" where MM is 00 or 30')
 
   yield cli.action(`Setting maintenance window for ${cli.color.addon(db.name)} to ${cli.color.cyan(args.window)}`, co(function * () {
-    let response = yield heroku.put(`/client/v11/databases/${db.name}/maintenance_window`, {
+    let response = yield heroku.put(`/client/v11/databases/${db.id}/maintenance_window`, {
       body: {description: args.window},
       host: host(db)
     })

--- a/commands/reset.js
+++ b/commands/reset.js
@@ -14,7 +14,7 @@ ${cli.color.addon(db.name)} will lose all of its data
 `)
 
   yield cli.action(`Resetting ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.put(`/client/v11/databases/${db.name}/reset`, {host: host(db)})
+    yield heroku.put(`/client/v11/databases/${db.id}/reset`, {host: host(db)})
   }))
 }
 

--- a/commands/unfollow.js
+++ b/commands/unfollow.js
@@ -10,7 +10,7 @@ function * run (context, heroku) {
   let {app, args, flags} = context
   let db = yield fetcher.addon(app, args.database)
 
-  let replica = yield heroku.get(`/client/v11/databases/${db.name}`, {host: host(db)})
+  let replica = yield heroku.get(`/client/v11/databases/${db.id}`, {host: host(db)})
 
   if (!replica.following) throw new Error(`${cli.color.addon(db.name)} is not a follower`)
 
@@ -20,7 +20,7 @@ ${cli.color.addon(db.name)} will become writeable and no longer follow ${origin}
 `)
 
   yield cli.action(`${cli.color.addon(db.name)} unfollowing`, co(function * () {
-    yield heroku.put(`/client/v11/databases/${db.name}/unfollow`, {host: host(db)})
+    yield heroku.put(`/client/v11/databases/${db.id}/unfollow`, {host: host(db)})
   }))
 }
 

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -13,8 +13,8 @@ function * run (context, heroku) {
   if (util.starterPlan(db)) throw new Error('pg:upgrade is only available for follower production databases')
 
   let [replica, status] = yield [
-    heroku.get(`/client/v11/databases/${db.name}`, {host: host(db)}),
-    heroku.get(`/client/v11/databases/${db.name}/upgrade_status`, {host: host(db)})
+    heroku.get(`/client/v11/databases/${db.id}`, {host: host(db)}),
+    heroku.get(`/client/v11/databases/${db.id}/upgrade_status`, {host: host(db)})
   ]
 
   if (status.error) throw new Error(status.error)
@@ -26,7 +26,7 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 This cannot be undone.`)
 
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.post(`/client/v11/databases/${db.name}/upgrade`, {host: host(db)})
+    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db)})
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
   }))
 }

--- a/commands/wait.js
+++ b/commands/wait.js
@@ -20,7 +20,7 @@ function * run (context, heroku) {
     while (true) {
       status = yield heroku.request({
         host: host(db),
-        path: `/client/v11/databases/${db.name}/wait_status`
+        path: `/client/v11/databases/${db.id}/wait_status`
       })
 
       if (status['error?']) {

--- a/test/commands/backups/capture.js
+++ b/test/commands/backups/capture.js
@@ -5,7 +5,7 @@ const cli = require('heroku-cli-util')
 const expect = require('unexpected')
 const nock = require('nock')
 
-const addon = {name: 'postgres-1', plan: {name: 'heroku-postgresql:standard-0'}, app: {name: 'myapp'}}
+const addon = {id: 1, name: 'postgres-1', plan: {name: 'heroku-postgresql:standard-0'}, app: {name: 'myapp'}}
 
 const cmd = require('../../../commands/backups/capture')
 
@@ -33,7 +33,7 @@ const shouldCapture = function (cmdRun) {
     api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
-    pg.post('/client/v11/databases/postgres-1/backups').reply(200, {
+    pg.post('/client/v11/databases/1/backups').reply(200, {
       num: 5,
       from_name: 'DATABASE',
       uuid: '100-001'
@@ -60,7 +60,7 @@ Stop a running backup with heroku pg:backups:cancel.
     api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
-    pg.post('/client/v11/databases/postgres-1/backups').reply(200, {
+    pg.post('/client/v11/databases/1/backups').reply(200, {
       num: 5,
       from_name: 'DATABASE',
       uuid: '100-001'
@@ -91,7 +91,7 @@ Backing up DATABASE to b005...
     api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
-    pg.post('/client/v11/databases/postgres-1/backups').reply(200, {
+    pg.post('/client/v11/databases/1/backups').reply(200, {
       num: 5,
       from_name: 'DATABASE',
       uuid: '100-001'

--- a/test/commands/backups/restore.js
+++ b/test/commands/backups/restore.js
@@ -5,7 +5,7 @@ const cli = require('heroku-cli-util')
 const expect = require('unexpected')
 const nock = require('nock')
 
-const addon = {name: 'postgres-1', plan: {name: 'heroku-postgresql:standard-0'}, app: {name: 'myapp'}}
+const addon = {id: 1, name: 'postgres-1', plan: {name: 'heroku-postgresql:standard-0'}, app: {name: 'myapp'}}
 
 const cmd = require('../../../commands/backups/restore')
 
@@ -36,7 +36,7 @@ const shouldRestore = function (cmdRun) {
       pg.get('/client/v11/apps/myapp/transfers').reply(200, [
         {num: 5, from_type: 'pg_dump', to_type: 'gof3r', succeeded: true, to_url: 'https://myurl'}
       ])
-      pg.post('/client/v11/databases/postgres-1/restores', {backup_url: 'https://myurl'}).reply(200, {
+      pg.post('/client/v11/databases/1/restores', {backup_url: 'https://myurl'}).reply(200, {
         num: 5,
         from_name: 'DATABASE',
         uuid: '100-001'
@@ -86,7 +86,7 @@ Stop a running restore with heroku pg:backups:cancel.
       pg.get('/client/v11/apps/myapp/transfers').reply(200, [
         {num: 5, from_type: 'pg_dump', to_type: 'gof3r', succeeded: true, to_url: 'https://myurl'}
       ])
-      pg.post('/client/v11/databases/postgres-1/restores', {backup_url: 'https://myurl'}).reply(200, {
+      pg.post('/client/v11/databases/1/restores', {backup_url: 'https://myurl'}).reply(200, {
         num: 5,
         from_name: 'DATABASE',
         uuid: '100-001'
@@ -114,7 +114,7 @@ Restoring...
 
   context('with a URL', () => {
     beforeEach(() => {
-      pg.post('/client/v11/databases/postgres-1/restores', {backup_url: 'https://www.dropbox.com?dl=1'}).reply(200, {
+      pg.post('/client/v11/databases/1/restores', {backup_url: 'https://www.dropbox.com?dl=1'}).reply(200, {
         num: 5,
         from_name: 'DATABASE',
         uuid: '100-001'

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -14,6 +14,7 @@ const shouldSchedule = function (cmdRun) {
     api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [
       {
         addon: {
+          id: 1,
           name: 'postgres-1',
           plan: {name: 'heroku-postgresql:standard-0'}
         },
@@ -33,7 +34,7 @@ const shouldSchedule = function (cmdRun) {
   })
 
   it('schedules a backup', () => {
-    pg.post('/client/v11/databases/postgres-1/transfer-schedules', {
+    pg.post('/client/v11/databases/1/transfer-schedules', {
       'hour': '06', 'timezone': 'America/New_York', 'schedule_name': 'DATABASE_URL'
     }).reply(201)
     return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})

--- a/test/commands/backups/schedules.js
+++ b/test/commands/backups/schedules.js
@@ -29,6 +29,7 @@ const shouldSchedules = function (cmdRun) {
   context('with databases', () => {
     beforeEach(() => {
       api.get('/apps/myapp/addons').reply(200, [{
+        id: 1,
         name: 'postgres-1',
         plan: {name: 'heroku-postgresql:standard-0'},
         app: {name: 'myapp'}
@@ -36,12 +37,12 @@ const shouldSchedules = function (cmdRun) {
     })
 
     it('shows empty message with no schedules', () => {
-      pg.get('/client/v11/databases/postgres-1/transfer-schedules').reply(200, [])
+      pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [])
       return expect(cmdRun({app: 'myapp'}), 'to be rejected with', 'No backup schedules found on myapp\nUse heroku pg:backups:schedule to set one up')
     })
 
     it('shows schedule', () => {
-      pg.get('/client/v11/databases/postgres-1/transfer-schedules').reply(200, [
+      pg.get('/client/v11/databases/1/transfer-schedules').reply(200, [
         {name: 'DATABASE_URL', hour: 5, timezone: 'UTC'}
       ])
       return cmdRun({app: 'myapp'})

--- a/test/commands/backups/unschedule.js
+++ b/test/commands/backups/unschedule.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const cmd = require('../../..').commands.find(c => c.topic === 'pg' && c.command === 'backups:unschedule')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   app: {name: 'myapp'},
   plan: {name: 'heroku-postgresql:standard-0'}
@@ -22,8 +23,8 @@ const shouldUnschedule = function (cmdRun) {
     api.get('/apps/myapp/addons').reply(200, [addon])
     api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [attachment])
     pg = nock('https://postgres-api.heroku.com')
-    pg.get('/client/v11/databases/postgres-1/transfer-schedules').twice().reply(200, [{name: 'DATABASE_URL', uuid: '100-001'}])
-    pg.delete('/client/v11/databases/postgres-1/transfer-schedules/100-001').reply(200)
+    pg.get('/client/v11/databases/1/transfer-schedules').twice().reply(200, [{name: 'DATABASE_URL', uuid: '100-001'}])
+    pg.delete('/client/v11/databases/1/transfer-schedules/100-001').reply(200)
     cli.mockConsole()
   })
 

--- a/test/commands/copy.js
+++ b/test/commands/copy.js
@@ -8,6 +8,7 @@ const nock = require('nock')
 const cmd = require('../..').commands.find(c => c.topic === 'pg' && c.command === 'copy')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   app: {name: 'myapp'},
   config_vars: ['DATABASE_URL'],
@@ -46,7 +47,7 @@ describe('pg:copy', () => {
       api.get('/addons/postgres-1').reply(200, addon)
       api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [attachment])
       api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
-      pg.post('/client/v11/databases/postgres-1/transfers', {
+      pg.post('/client/v11/databases/1/transfers', {
         from_name: 'database bar on foo.com:5432',
         from_url: 'postgres://foo.com/bar',
         to_name: 'RED',
@@ -67,7 +68,7 @@ describe('pg:copy', () => {
       api.get('/addons/postgres-1').reply(200, addon)
       api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [attachment])
       api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
-      pg.post('/client/v11/databases/postgres-1/transfers', {
+      pg.post('/client/v11/databases/1/transfers', {
         from_name: 'database bar on foo.com:5432',
         from_url: 'postgres://foo.com/bar',
         to_name: 'RED',

--- a/test/commands/credentials.js
+++ b/test/commands/credentials.js
@@ -15,6 +15,7 @@ const db = {
 }
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -54,7 +55,7 @@ Connection URL:
   })
 
   it('resets credentials', () => {
-    pg.post('/client/v11/databases/postgres-1/credentials_rotation').reply(200)
+    pg.post('/client/v11/databases/1/credentials_rotation').reply(200)
     return cmd.run({app: 'myapp', args: {}, flags: {reset: true}})
     .then(() => expect(cli.stdout, 'to equal', ''))
     .then(() => expect(cli.stderr, 'to equal', 'Resetting credentials on postgres-1... done\n'))

--- a/test/commands/diagnose.js
+++ b/test/commands/diagnose.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const db = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'},
   config_vars: ['DATABASE_URL'],
@@ -42,7 +43,7 @@ describe('pg:diagnose', () => {
   it('generates a report', () => {
     api.get('/addons/postgres-1').reply(200, db)
     api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://db'})
-    pg.get('/client/v11/databases/postgres-1/metrics').reply(200, [])
+    pg.get('/client/v11/databases/1/metrics').reply(200, [])
     diagnose.post('/reports', {
       url: 'postgres://db',
       plan: 'standard-0',

--- a/test/commands/info.js
+++ b/test/commands/info.js
@@ -74,8 +74,8 @@ describe('pg', () => {
 
       api.get('/apps/myapp/config-vars').reply(200, config)
       pg
-      .get('/client/v11/databases/postgres-1').reply(200, dbA)
-      .get('/client/v11/databases/postgres-2').reply(200, dbB)
+      .get('/client/v11/databases/1').reply(200, dbA)
+      .get('/client/v11/databases/2').reply(200, dbB)
 
       return cmd.run({app: 'myapp', args: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== DATABASE_URL, HEROKU_POSTGRESQL_COBALT_URL
@@ -101,8 +101,8 @@ Add-on:    postgres-2
 
       api.get('/apps/myapp/config-vars').reply(200, config)
       pg
-      .get('/client/v11/databases/postgres-1').reply(200, dbA)
-      .get('/client/v11/databases/postgres-2').reply(200, dbB)
+      .get('/client/v11/databases/1').reply(200, dbA)
+      .get('/client/v11/databases/2').reply(200, dbB)
 
       return cmd.run({app: 'myapp', args: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== DATABASE_URL, ATTACHMENT_NAME_URL
@@ -124,7 +124,7 @@ Add-on:    postgres-2
       api.get('/apps/myapp/config-vars').reply(200, config)
 
       pg
-      .get('/client/v11/databases/postgres-2')
+      .get('/client/v11/databases/2')
       .reply(200, dbB)
       return cmd.run({app: 'myapp', args: {database: 'postgres-2'}})
       .then(() => expect(cli.stdout, 'to equal', `=== HEROKU_POSTGRESQL_PURPLE_URL
@@ -141,8 +141,8 @@ Add-on:    postgres-2
 
       api.get('/apps/myapp/config-vars').reply(200, config)
       pg
-      .get('/client/v11/databases/postgres-1').reply(404)
-      .get('/client/v11/databases/postgres-2').reply(200, dbB)
+      .get('/client/v11/databases/1').reply(404)
+      .get('/client/v11/databases/2').reply(200, dbB)
 
       return cmd.run({app: 'myapp', args: {}})
       .then(() => expect(cli.stdout, 'to equal', `=== HEROKU_POSTGRESQL_PURPLE_URL

--- a/test/commands/killall.js
+++ b/test/commands/killall.js
@@ -6,7 +6,7 @@ const expect = require('unexpected')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 
-const db = {name: 'postgres-1', plan: {name: 'heroku-postgresql:hobby-dev'}}
+const db = {id: 1, name: 'postgres-1', plan: {name: 'heroku-postgresql:hobby-dev'}}
 const fetcher = () => {
   return {
     addon: () => db
@@ -33,7 +33,7 @@ describe('pg:killall', () => {
 
   it('waits for all databases to be available', () => {
     pg
-      .post('/client/v11/databases/postgres-1/connection_reset').reply(200)
+      .post('/client/v11/databases/1/connection_reset').reply(200)
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})
       .then(() => expect(cli.stdout, 'to equal', ''))

--- a/test/commands/links/create.js
+++ b/test/commands/links/create.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -37,7 +38,7 @@ describe('pg:links:create', () => {
   })
 
   it('creates a link', () => {
-    pg.post('/client/v11/databases/postgres-1/links', {target: 'postgres-1', as: 'foobar'}).reply(200, {name: 'foobar'})
+    pg.post('/client/v11/databases/1/links', {target: 'postgres-1', as: 'foobar'}).reply(200, {name: 'foobar'})
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', as: 'foobar'}})
     .then(() => expect(cli.stdout, 'to equal', ''))
     .then(() => expect(cli.stderr, 'to equal', 'Adding link from postgres-1 to postgres-1... done, foobar\n'))

--- a/test/commands/links/destroy.js
+++ b/test/commands/links/destroy.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -37,7 +38,7 @@ describe('pg:links:destroy', () => {
   })
 
   it('destroys a link', () => {
-    pg.delete('/client/v11/databases/postgres-1/links/redis').reply(200)
+    pg.delete('/client/v11/databases/1/links/redis').reply(200)
     return cmd.run({app: 'myapp', args: {link: 'redis'}, flags: {confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', ''))
     .then(() => expect(cli.stderr, 'to equal', 'Destroying link redis from postgres-1... done\n'))

--- a/test/commands/links/index.js
+++ b/test/commands/links/index.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -37,7 +38,7 @@ describe('pg:links', () => {
   })
 
   it('shows links', () => {
-    pg.get('/client/v11/databases/postgres-1/links').reply(200, [
+    pg.get('/client/v11/databases/1/links').reply(200, [
       {name: 'redis-link-1', created_at: '100', remote: {attachment_name: 'REDIS', name: 'redis-001'}}
     ])
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})

--- a/test/commands/maintenance/index.js
+++ b/test/commands/maintenance/index.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const db = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -36,7 +37,7 @@ describe('pg:maintenance', () => {
   })
 
   it('shows maintenance', () => {
-    pg.get('/client/v11/databases/postgres-1/maintenance').reply(200, {message: 'foo'})
+    pg.get('/client/v11/databases/1/maintenance').reply(200, {message: 'foo'})
     return cmd.run({app: 'myapp', args: {}, flags: {}})
     .then(() => expect(cli.stdout, 'to equal', 'foo\n'))
   })

--- a/test/commands/maintenance/run.js
+++ b/test/commands/maintenance/run.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const db = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -37,7 +38,7 @@ describe('pg:maintenance', () => {
 
   it('runs maintenance', () => {
     api.get('/apps/myapp').reply(200, {maintenance: true})
-    pg.post('/client/v11/databases/postgres-1/maintenance').reply(200, {message: 'foo'})
+    pg.post('/client/v11/databases/1/maintenance').reply(200, {message: 'foo'})
     return cmd.run({app: 'myapp', args: {}, flags: {}})
     .then(() => expect(cli.stderr, 'to equal', 'Starting maintenance for postgres-1... foo\n'))
     .then(() => expect(cli.stdout, 'to equal', ''))

--- a/test/commands/maintenance/window.js
+++ b/test/commands/maintenance/window.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const db = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -36,7 +37,7 @@ describe('pg:maintenance', () => {
   })
 
   it('sets maintenance window', () => {
-    pg.put('/client/v11/databases/postgres-1/maintenance_window', {description: 'Sunday 06:30'}).reply(200)
+    pg.put('/client/v11/databases/1/maintenance_window', {description: 'Sunday 06:30'}).reply(200)
     return cmd.run({app: 'myapp', args: {window: 'Sunday 06:30'}})
     .then(() => expect(cli.stdout, 'to equal', ''))
     .then(() => expect(cli.stderr, 'to equal', 'Setting maintenance window for postgres-1 to Sunday 06:30... done\n'))

--- a/test/commands/reset.js
+++ b/test/commands/reset.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -36,7 +37,7 @@ describe('pg:reset', () => {
   })
 
   it('reset db', () => {
-    pg.put('/client/v11/databases/postgres-1/reset').reply(200)
+    pg.put('/client/v11/databases/1/reset').reply(200)
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
     .then(() => expect(cli.stderr, 'to equal', 'Resetting postgres-1... done\n'))
   })

--- a/test/commands/unfollow.js
+++ b/test/commands/unfollow.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -37,8 +38,8 @@ describe('pg:unfollow', () => {
 
   it('unfollows db', () => {
     api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://db1'})
-    pg.get('/client/v11/databases/postgres-1').reply(200, {following: 'postgres://db1'})
-    pg.put('/client/v11/databases/postgres-1/unfollow').reply(200)
+    pg.get('/client/v11/databases/1').reply(200, {following: 'postgres://db1'})
+    pg.put('/client/v11/databases/1/unfollow').reply(200)
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
     .then(() => expect(cli.stderr, 'to equal', 'postgres-1 unfollowing... done\n'))
   })

--- a/test/commands/upgrade.js
+++ b/test/commands/upgrade.js
@@ -7,6 +7,7 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const addon = {
+  id: 1,
   name: 'postgres-1',
   plan: {name: 'heroku-postgresql:standard-0'}
 }
@@ -37,9 +38,9 @@ describe('pg:upgrade', () => {
 
   it('upgrades db', () => {
     api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://db1'})
-    pg.get('/client/v11/databases/postgres-1').reply(200, {following: 'postgres://db1'})
-    pg.get('/client/v11/databases/postgres-1/upgrade_status').reply(200, {})
-    pg.post('/client/v11/databases/postgres-1/upgrade').reply(200)
+    pg.get('/client/v11/databases/1').reply(200, {following: 'postgres://db1'})
+    pg.get('/client/v11/databases/1/upgrade_status').reply(200, {})
+    pg.post('/client/v11/databases/1/upgrade').reply(200)
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
     .then(() => expect(cli.stderr, 'to equal', 'Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
   })

--- a/test/commands/wait.js
+++ b/test/commands/wait.js
@@ -7,8 +7,8 @@ const nock = require('nock')
 const proxyquire = require('proxyquire')
 
 const all = [
-  {name: 'postgres-1', plan: {name: 'heroku-postgresql:hobby-dev'}},
-  {name: 'postgres-2', plan: {name: 'heroku-postgresql:hobby-dev'}}
+  {id: 1, name: 'postgres-1', plan: {name: 'heroku-postgresql:hobby-dev'}},
+  {id: 2, name: 'postgres-2', plan: {name: 'heroku-postgresql:hobby-dev'}}
 ]
 const fetcher = () => {
   return {
@@ -37,8 +37,8 @@ describe('pg:wait', () => {
 
   it('waits for a database to be available', () => {
     pg
-      .get('/client/v11/databases/postgres-1/wait_status').reply(200, {'waiting?': true, message: 'pending'})
-      .get('/client/v11/databases/postgres-1/wait_status').reply(200, {'waiting?': false, message: 'available'})
+      .get('/client/v11/databases/1/wait_status').reply(200, {'waiting?': true, message: 'pending'})
+      .get('/client/v11/databases/1/wait_status').reply(200, {'waiting?': false, message: 'available'})
 
     return cmd.run({app: 'myapp', args: {database: 'DATABASE_URL'}, flags: {'wait-interval': '1'}})
       .then(() => expect(cli.stdout, 'to equal', ''))
@@ -49,8 +49,8 @@ Waiting for database postgres-1... available
 
   it('waits for all databases to be available', () => {
     pg
-      .get('/client/v11/databases/postgres-1/wait_status').reply(200, {'waiting?': false})
-      .get('/client/v11/databases/postgres-2/wait_status').reply(200, {'waiting?': false})
+      .get('/client/v11/databases/1/wait_status').reply(200, {'waiting?': false})
+      .get('/client/v11/databases/2/wait_status').reply(200, {'waiting?': false})
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})
       .then(() => expect(cli.stdout, 'to equal', ''))
@@ -59,7 +59,7 @@ Waiting for database postgres-1... available
 
   it('displays errors', () => {
     pg
-      .get('/client/v11/databases/postgres-1/wait_status').reply(200, {'error?': true, message: 'this is an error message'})
+      .get('/client/v11/databases/1/wait_status').reply(200, {'error?': true, message: 'this is an error message'})
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})
       .catch(err => {


### PR DESCRIPTION
This is more consistent with DHC and the Kafka CLI and works around
issues around add-on renames and Shogun sync.