### PR TITLE
Psql drop timeout

### DIFF
--- a/lib/psql.js
+++ b/lib/psql.js
@@ -13,24 +13,22 @@ function handlePsqlError (reject, psql) {
   })
 }
 
-function execPsql (query, dbEnv, timeout) {
+function execPsql (query, dbEnv) {
   const {spawn} = require('child_process')
   return new Promise((resolve, reject) => {
-    let timer = setTimeout(() => reject('psql call timed out'), timeout)
     let result = ''
     let psql = spawn('psql', ['-c', query], {env: dbEnv, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ]})
     psql.stdout.on('data', function (data) {
       result += data.toString()
     })
     psql.on('close', function (code) {
-      clearTimeout(timer)
       resolve(result)
     })
     handlePsqlError(reject, psql)
   })
 }
 
-function psqlInteractive (dbEnv, prompt, timeout) {
+function psqlInteractive (dbEnv, prompt) {
   const {spawn} = require('child_process')
   return new Promise((resolve, reject) => {
     let psql = spawn('psql',
@@ -47,12 +45,12 @@ function handleSignals () {
   process.on('SIGINT', () => {})
 }
 
-function * exec (db, query, timeout = 20000) {
+function * exec (db, query) {
   handleSignals()
   let configs = bastion.getConfigs(db)
 
-  yield bastion.sshTunnel(db, configs.dbTunnelConfig, timeout)
-  return yield execPsql(query, configs.dbEnv, timeout)
+  yield bastion.sshTunnel(db, configs.dbTunnelConfig)
+  return yield execPsql(query, configs.dbEnv)
 }
 
 function * interactive (db) {


### PR DESCRIPTION
This causes problems for long-running queries, and is only really
useful for a slightly nicer experience in the rare cases when the
bastion or service is unavailable.

Fixes #94.

The second commit fixes tests. Some of these had bad mocking and seemed to rely on the timeout to pass. This fixes them and removes the timeout catch.
