### PR TITLE
Attachment info cli commands

### DIFF
--- a/commands/credentials/create.js
+++ b/commands/credentials/create.js
@@ -19,7 +19,7 @@ function * run (context, heroku) {
   yield cli.action(`Creating credential ${cli.color.cmd(flags.name)}`, co(function * () {
     yield heroku.post(`/postgres/v0/databases/${db.name}/credentials`, {host: host(db), body: data})
   }))
-  let attachCmd = `heroku addons:attach --credential ${flags.name} -a app_name`
+  let attachCmd = `heroku addons:attach ${db.name} --credential ${flags.name} -a app_name`
   let psqlCmd = `heroku pg:psql ${db.name} -a ${app}`
   cli.log(`
 Please attach the credential to the apps you want to use it in by running ${cli.color.cmd(attachCmd)}.

--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -22,15 +22,21 @@ function * run (context, heroku) {
     attachments = attachments.filter(a => a.namespace === `credential:${cred}`)
   }
 
-  let warning = all ? `Connections will be reset and applications will be restarted.` :
-`The password for the ${cred} credential will rotate.
-Connections older than 30 minutes will be reset, and a temporary rotation username will be used during the process.`
+  let warnings = []
+  if (!flags.all) {
+    warnings.push(`The password for the ${cred} credential will rotate.`)
+  }
+  if (flags.all || flags.force) {
+    warnings.push(`Connections will be reset and applications will be restarted.`)
+  } else {
+    warnings.push(`Connections older than 30 minutes will be reset, and a temporary rotation username will be used during the process.`)
+  }
   if (attachments.length > 0) {
-    warning += `\nThis command will affect the app${ (attachments.length > 1) ? 's' : ''} ${[...new Set(attachments.map(c => cli.color.app(c.app.name)))].sort().join(', ')}`
+    warnings.push(`This command will affect the app${(attachments.length > 1) ? 's' : ''} ${[...new Set(attachments.map(c => cli.color.app(c.app.name)))].sort().join(', ')}.`)
   }
 
   yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive Action
-${warning}`)
+${warnings.join('\n')}`)
 
   let body = flags.force ? {host: host(db), force: true} : {host: host(db)}
 

--- a/test/commands/credentials/create.js
+++ b/test/commands/credentials/create.js
@@ -48,7 +48,7 @@ describe('pg:credentials:create', () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials').reply(200)
     return cmd.run({app: 'myapp', args: {}, flags: {name: 'credname'}})
     .then(() => expect(cli.stdout, 'to equal', `
-Please attach the credential to the apps you want to use it in by running heroku addons:attach --credential credname -a app_name.
+Please attach the credential to the apps you want to use it in by running heroku addons:attach postgres-1 --credential credname -a app_name.
 Please define the new grants for the credential within Postgres: heroku pg:psql postgres-1 -a myapp.
 `))
     .then(() => expect(cli.stderr, 'to equal', 'Creating credential credname... done\n'))


### PR DESCRIPTION
## What is this?

* Provide meaningful attachment information in the confirmation warning for rotating credentials. 
* Correct the attachCmd copy which should include the name of the database to avoid confusing error messages

## Notes

This PR is based on the `pg-credentials` branch, once the `pg-credentials` branch is merged, I will point it to master. 