### PR TITLE
Add attachment info to pg:credentials

### DIFF
--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -2,6 +2,8 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
+const sortBy = require('lodash.sortby')
+const printf = require('printf')
 
 function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
@@ -11,12 +13,57 @@ function * run (context, heroku) {
   let showCredentials = co.wrap(function * () {
     const host = require('../lib/host')
     let addon = yield fetcher.addon(app, args.database)
+    let attachments = []
+
+    function formatAttachment (attachment) {
+      let attName = cli.color.addon(attachment.name)
+
+      let output = [cli.color.dim('as'), attName]
+      let appInfo = `on ${cli.color.app(attachment.app.name)} app`
+      output.push(cli.color.dim(appInfo))
+
+      return output.join(' ')
+    }
+
+    function renderAttachment (attachment, app, isFirst) {
+      let line = isFirst ? '└─' : '├─'
+      let attName = formatAttachment(attachment)
+      return printf(' %s %s', cli.color.dim(line), attName)
+    }
+
+    function presentCredential (cred) {
+      let credAttachments = []
+      if (cred !== 'default') {
+        credAttachments = attachments.filter(a => a.namespace === `credential:${cred}`)
+      } else {
+        credAttachments = attachments.filter(a => a.namespace === null)
+      }
+      let isForeignApp = (attOrAddon) => attOrAddon.app.name !== app
+      let atts = sortBy(credAttachments,
+        isForeignApp,
+        'name',
+        'app.name'
+      )
+
+      // render each attachment under the credential
+      let attLines = atts.map(function (attachment, idx) {
+        let isFirst = (idx === credAttachments.length - 1)
+        return renderAttachment(attachment, app, isFirst)
+      })
+
+      return [cred].concat(attLines).join('\n')
+    }
+
     try {
       let credentials = yield heroku.get(`/postgres/v0/databases/${addon.name}/credentials`,
                                        { host: host(addon) })
+      let isDefaultCredential = (cred) => cred.name !== 'default'
+      credentials = sortBy(credentials, isDefaultCredential, 'name')
+      attachments = yield heroku.get(`/addons/${addon.name}/addon-attachments`)
+
       cli.table(credentials, {
         columns: [
-          {key: 'name', label: 'Credential'},
+          {key: 'name', label: 'Credential', format: presentCredential},
           {key: 'state', label: 'State'}
         ]
       })

--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -25,8 +25,8 @@ function * run (context, heroku) {
       return output.join(' ')
     }
 
-    function renderAttachment (attachment, app, isFirst) {
-      let line = isFirst ? '└─' : '├─'
+    function renderAttachment (attachment, app, isLast) {
+      let line = isLast ? '└─' : '├─'
       let attName = formatAttachment(attachment)
       return printf(' %s %s', cli.color.dim(line), attName)
     }
@@ -47,8 +47,8 @@ function * run (context, heroku) {
 
       // render each attachment under the credential
       let attLines = atts.map(function (attachment, idx) {
-        let isFirst = (idx === credAttachments.length - 1)
-        return renderAttachment(attachment, app, isFirst)
+        let isLast = (idx === credAttachments.length - 1)
+        return renderAttachment(attachment, app, isLast)
       })
 
       return [cred].concat(attLines).join('\n')

--- a/test/commands/credentials.js
+++ b/test/commands/credentials.js
@@ -68,25 +68,66 @@ Connection URL:
   it('shows the correct credentials', () => {
     let credentials = [
       { uuid: 'aaaa',
-        name: 'jeff',
-        state: 'created',
+        name: 'ransom',
+        state: 'active',
+        database: 'd123',
+        host: 'localhost',
+        port: 5442,
+        credentials: [] },
+      { uuid: 'aaab',
+        name: 'default',
+        state: 'active',
         database: 'd123',
         host: 'localhost',
         port: 5442,
         credentials: [] },
       { uuid: 'aabb',
-        name: 'ransom',
+        name: 'jeff',
         state: 'rotating',
         database: 'd123',
         host: 'localhost',
         port: 5442,
         credentials: [] }
     ]
+    let attachments = [
+      {
+        app: { name: 'main-app' },
+        name: 'DATABASE',
+        namespace: null
+      },
+      {
+        app: { name: 'main-app' },
+        name: 'HEROKU_POSTGRESQL_GREEN',
+        namespace: 'credential:jeff'
+      },
+      {
+        app: { name: 'another-app' },
+        name: 'HEROKU_POSTGRESQL_PINK',
+        namespace: 'credential:jeff'
+      },
+      {
+        app: { name: 'yet-another-app' },
+        name: 'HEROKU_POSTGRESQL_BLUE',
+        namespace: 'credential:ransom'
+      }
+    ]
+    api.get(`/addons/postgres-1/addon-attachments`).reply(200, attachments)
     pg.get('/postgres/v0/databases/postgres-1/credentials').reply(200, credentials)
+
+    let displayed = `Credential                                            State
+────────────────────────────────────────────────────  ────────
+default                                               active
+ └─ as DATABASE on main-app app
+jeff                                                  rotating
+ ├─ as HEROKU_POSTGRESQL_GREEN on main-app app
+ └─ as HEROKU_POSTGRESQL_PINK on another-app app
+ransom                                                active
+ └─ as HEROKU_POSTGRESQL_BLUE on yet-another-app app
+`
 
     return cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}})
               .then(() => expect(cli.stdout,
                                  'to equal',
-                                 'Credential  State\n──────────  ────────\njeff        created\nransom      rotating\n'))
+                                 displayed))
   })
 })


### PR DESCRIPTION
## What is this?

* Provide attachment information in the list of credentials
* Order default first

## Notes

This PR is based on the `pg-credentials` branch, once the `pg-credentials` branch is merged, I will point it to master. 