### PR TITLE
Review credential commands applying to hobby databases and messaging

### DIFF
--- a/commands/credentials/destroy.js
+++ b/commands/credentials/destroy.js
@@ -17,8 +17,7 @@ function * run (context, heroku) {
 
   let db = yield fetcher.addon(app, args.database)
   if (util.starterPlan(db)) {
-    throw new Error(`Could not find credential ${cred} for database ${db.name}.
-Only one default credential is supported for Hobby tier databases.`)
+    throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
 
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)

--- a/commands/credentials/destroy.js
+++ b/commands/credentials/destroy.js
@@ -11,8 +11,15 @@ function * run (context, heroku) {
   const {app, args, flags} = context
   let cred = flags.name
 
+  if (cred === 'default') {
+    throw new Error('Default credential cannot be destroyed.')
+  }
+
   let db = yield fetcher.addon(app, args.database)
-  if (util.starterPlan(db)) throw new Error('This operation is not supported by Hobby tier databases.')
+  if (util.starterPlan(db)) {
+    throw new Error(`Could not find credential ${cred} for database ${db.name}.
+Only one default credential is supported for Hobby tier databases.`)
+  }
 
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   let credAttachments = attachments.filter(a => a.namespace === `credential:${flags.name}`)

--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -15,8 +15,13 @@ function * run (context, heroku) {
     cli.exit(1, 'cannot pass both --all and --name')
   }
   let cred = flags.name || 'default'
-  if (util.starterPlan(db) && cred !== 'default') throw new Error('This operation is not supported by Hobby tier databases.')
-
+  if (cred === 'default' && 'force' in flags && !all) {
+    cli.exit(1, 'Cannot force rotate the default credential.')
+  }
+  if (util.starterPlan(db) && cred !== 'default') {
+    throw new Error(`Could not find credential ${cred} for database ${db.name}.
+Only one default credential is supported for Hobby tier databases.`)
+  }
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   if (flags.name) {
     attachments = attachments.filter(a => a.namespace === `credential:${cred}`)
@@ -26,7 +31,7 @@ function * run (context, heroku) {
   if (!flags.all) {
     warnings.push(`The password for the ${cred} credential will rotate.`)
   }
-  if (flags.all || flags.force) {
+  if (flags.all || flags.force || cred === 'default') {
     warnings.push(`Connections will be reset and applications will be restarted.`)
   } else {
     warnings.push(`Connections older than 30 minutes will be reset, and a temporary rotation username will be used during the process.`)

--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -19,8 +19,7 @@ function * run (context, heroku) {
     cli.exit(1, 'Cannot force rotate the default credential.')
   }
   if (util.starterPlan(db) && cred !== 'default') {
-    throw new Error(`Could not find credential ${cred} for database ${db.name}.
-Only one default credential is supported for Hobby tier databases.`)
+    throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   if (flags.name) {

--- a/commands/credentials/url.js
+++ b/commands/credentials/url.js
@@ -13,7 +13,10 @@ function * run (context, heroku) {
 
   let db = yield fetcher.addon(app, args.database)
   let cred = flags.name || 'default'
-  if (util.starterPlan(db) && cred !== 'default') throw new Error('This operation is not supported by Hobby tier databases.')
+  if (util.starterPlan(db) && cred !== 'default') {
+    throw new Error(`Could not find credential ${cred} for database ${db.name}.
+Only one default credential is supported for Hobby tier databases.`)
+  }
   let credInfo = yield heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,
                                    { host: host(db) })
 

--- a/commands/credentials/url.js
+++ b/commands/credentials/url.js
@@ -14,8 +14,7 @@ function * run (context, heroku) {
   let db = yield fetcher.addon(app, args.database)
   let cred = flags.name || 'default'
   if (util.starterPlan(db) && cred !== 'default') {
-    throw new Error(`Could not find credential ${cred} for database ${db.name}.
-Only one default credential is supported for Hobby tier databases.`)
+    throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
   let credInfo = yield heroku.get(`/postgres/v0/databases/${db.name}/credentials/${encodeURIComponent(cred)}`,
                                    { host: host(db) })

--- a/test/commands/credentials/destroy.js
+++ b/test/commands/credentials/destroy.js
@@ -78,8 +78,7 @@ Database objects owned by credname will be assigned to the default credential.
       '../../lib/fetcher': fetcher
     })
 
-    const err = new Error(`Could not find credential jeff for database postgres-1.
-Only one default credential is supported for Hobby tier databases.`)
+    const err = new Error(`Only one default credential is supported for Hobby tier databases.`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 

--- a/test/commands/credentials/destroy.js
+++ b/test/commands/credentials/destroy.js
@@ -78,7 +78,8 @@ Database objects owned by credname will be assigned to the default credential.
       '../../lib/fetcher': fetcher
     })
 
-    const err = new Error('This operation is not supported by Hobby tier databases.')
+    const err = new Error(`Could not find credential jeff for database postgres-1.
+Only one default credential is supported for Hobby tier databases.`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -128,7 +128,8 @@ describe('pg:credentials:rotate', () => {
       '../../lib/fetcher': fetcher
     })
 
-    const err = new Error('This operation is not supported by Hobby tier databases.')
+    const err = new Error(`Could not find credential jeff for database postgres-1.
+Only one default credential is supported for Hobby tier databases.`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -128,8 +128,7 @@ describe('pg:credentials:rotate', () => {
       '../../lib/fetcher': fetcher
     })
 
-    const err = new Error(`Could not find credential jeff for database postgres-1.
-Only one default credential is supported for Hobby tier databases.`)
+    const err = new Error(`Only one default credential is supported for Hobby tier databases.`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 

--- a/test/commands/credentials/url.js
+++ b/test/commands/credentials/url.js
@@ -93,7 +93,8 @@ Connection URL:
       '../../lib/fetcher': fetcher
     })
 
-    const err = new Error('This operation is not supported by Hobby tier databases.')
+    const err = new Error(`Could not find credential jeff for database postgres-1.
+Only one default credential is supported for Hobby tier databases.`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 

--- a/test/commands/credentials/url.js
+++ b/test/commands/credentials/url.js
@@ -93,8 +93,7 @@ Connection URL:
       '../../lib/fetcher': fetcher
     })
 
-    const err = new Error(`Could not find credential jeff for database postgres-1.
-Only one default credential is supported for Hobby tier databases.`)
+    const err = new Error(`Only one default credential is supported for Hobby tier databases.`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 


### PR DESCRIPTION
(I'm going to add a couple new tests for some edge cases uncovered while doing this). 

Commands for hobby:

* `heroku pg:credentials:create --name nope -a camille-hobby-app`

`This operation is not supported by Hobby tier databases.`

* `heroku pg:credentials:repair-default -a camille-hobby-app`

`This operation is not supported by Hobby tier databases.`

* `heroku pg:credentials -a camille-hobby-app`

```
Credential  State
──────────  ──────
default     active
```

* `heroku pg:credentials --reset -a camille-hobby-app`

`Resetting credentials on postgresql-polished-42344... done`

* `heroku pg:credentials:url -a camille-hobby-app`

```
Connection information for default credential.
Connection info string:
   "dbname=something host=ec2-23-21-220-23.compute-1.amazonaws.com port=5432 user=something password=something sslmode=require"
Connection URL:
   postgres://something:something@ec2-23-21-220-23.compute-1.amazonaws.com:5432/something
```

* `heroku pg:credentials:url --name nope -a camille-hobby-app`

Currently:
`This operation is not supported by Hobby tier databases.`

Proposal:
`Could not find credential nope for database postgresql-hobby-56874.
Only one default credential is supported for Hobby tier databases.
`

* `heroku pg:credentials:rotate --all -a camille-hobby-app`

`Rotating all credentials on postgresql-polished-42344... done`

* `heroku pg:credentials:rotate --name default -a camille-hobby-app`

```
▸    WARNING: Destructive Action
▸    The password for the default credential will rotate.
▸    Connections will be reset and applications will be restarted.
▸    To proceed, type camille-hobby-app or re-run this
▸    command with --confirm camille-hobby-app

> camille-hobby-app
Rotating default on postgresql-polished-42344... done
```

* `heroku pg:credentials:rotate --name default --force -a camille-hobby-app`

```
▸    WARNING: Destructive Action
▸    The password for the default credential will rotate.
▸    Connections will be reset and applications will be restarted.
▸    To proceed, type camille-hobby-app or re-run this
▸    command with --confirm camille-hobby-app

> camille-hobby-app
Rotating default on postgresql-polished-42344... done
```

Current:
`Rotating default on postgresql-polished-42344... done`

Proposed:
`Cannot force rotate the default credential.`

* `heroku pg:credentials:rotate --name nope -a camille-hobby-app`

Currently:
`This operation is not supported by Hobby tier databases.`

Proposal:
`Could not find credential nope for database postgresql-hobby-56874.
Only one default credential is supported for Hobby tier databases.
`

* `heroku pg:credentials:destroy --name nope -a camille-hobby-app`

Currently:
`This operation is not supported by Hobby tier databases.`

Proposal:
`Could not find credential nope for database postgresql-hobby-56874.
Only one default credential is supported for Hobby tier databases.
`

* `heroku pg:credentials:destroy --name default -a camille-hobby-app`

Currently:
`Not found.`

Proposal:
`Default credential cannot be destroyed.`