### PR TITLE
Better error message when destroying a credential with attachments

### DIFF
--- a/commands/credentials/destroy.js
+++ b/commands/credentials/destroy.js
@@ -22,7 +22,7 @@ function * run (context, heroku) {
 
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   let credAttachments = attachments.filter(a => a.namespace === `credential:${flags.name}`)
-  if (credAttachments.length > 0) throw new Error(`Credential ${flags.name} must be detached from all other apps before destroying.`)
+  if (credAttachments.length > 0) throw new Error(`Credential ${flags.name} must be detached from the app${credAttachments.length > 1 ? 's' : ''} ${credAttachments.map(a => cli.color.app(a.app.name)).join(', ')} before destroying.`)
 
   yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action`)
 

--- a/test/commands/credentials/destroy.js
+++ b/test/commands/credentials/destroy.js
@@ -98,7 +98,7 @@ Database objects owned by credname will be assigned to the default credential.
     ]
     api.get('/addons/postgres-1/addon-attachments').reply(200, attachments)
 
-    const err = new Error('Credential jeff must be detached from all other apps before destroying.')
+    const err = new Error('Credential jeff must be detached from the app otherapp before destroying.')
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
 })


### PR DESCRIPTION
Before:
```
heroku pg:credentials:destroy --name hello -a camille-main-app

 ▸    Credential hello must be detached from all other apps before destroying.
```

After:
```
heroku pg:credentials:destroy --name hello -a camille-main-app

 ▸    Credential hello must be detached from the apps ⬢ camille-secondary-app, ⬢ camille-main-app before destroying.
```