### PR TITLE
Include username and transaction start in pg:ps output

### DIFF
--- a/commands/ps.js
+++ b/commands/ps.js
@@ -12,6 +12,7 @@ function * run (context, heroku) {
   const {verbose} = flags
 
   let db = yield fetcher.database(app, database)
+  let addon = yield fetcher.addon(app, database)
 
   const num = Math.random()
   const waitingMarker = `${num}${num}`
@@ -27,20 +28,18 @@ SELECT '${num}' || '${num}' WHERE EXISTS (
   let waiting = waitingOutput.includes(waitingMarker)
                 ? 'waiting'
                 : 'wait_event IS NOT NULL AS waiting'
-
   let query = `
 SELECT
  pid,
  state,
  application_name AS source,
+ usename AS username,
  age(now(),xact_start) AS running_for,
  ${waiting},
  query
 FROM pg_stat_activity
 WHERE
- query <> '<insufficient privilege>'
- ${verbose ? '' : "AND state <> 'idle'"}
- AND pid <> pg_backend_pid()
+ pid <> pg_backend_pid()
  ORDER BY query_start DESC
 `
 

--- a/test/commands/ps.js
+++ b/test/commands/ps.js
@@ -44,6 +44,7 @@ describe('pg:ps', () => {
  pid,
  state,
  application_name AS source,
+ usename,
  age(now(),xact_start) AS running_for,
  wait_event IS NOT NULL AS waiting,
  query
@@ -61,6 +62,7 @@ WHERE
  pid,
  state,
  application_name AS source,
+ usename,
  age(now(),xact_start) AS running_for,
  wait_event IS NOT NULL AS waiting,
  query


### PR DESCRIPTION
Before:

```
heroku pg:ps -a camille-main-app
 pid | state  |        source        |   running_for   | waiting |        query         
-----+--------+----------------------+-----------------+---------+----------------------
 198 | active | psql non-interactive | 00:00:06.198973 | f       | SELECT pg_sleep(10);
```

After:

```
heroku pg:ps -a camille-main-app
 pid | state  |        source        |    usename     |   running_for   | waiting |        query         
-----+--------+----------------------+----------------+-----------------+---------+----------------------
 198 | active | psql non-interactive | u8l0buj5sjbsj4 | 00:00:06.198973 | f       | SELECT pg_sleep(10);
```

I would love some feedback on what column to go for (is `usename` (what postgres defines) fine?). 