### PR TITLE
Include username and transaction start in pg:ps output

### DIFF
--- a/commands/ps.js
+++ b/commands/ps.js
@@ -27,13 +27,14 @@ SELECT '${num}' || '${num}' WHERE EXISTS (
   let waiting = waitingOutput.includes(waitingMarker)
                 ? 'waiting'
                 : 'wait_event IS NOT NULL AS waiting'
-
   let query = `
 SELECT
  pid,
  state,
  application_name AS source,
+ usename AS username,
  age(now(),xact_start) AS running_for,
+ xact_start AS transaction_start,
  ${waiting},
  query
 FROM pg_stat_activity

--- a/test/commands/ps.js
+++ b/test/commands/ps.js
@@ -44,7 +44,9 @@ describe('pg:ps', () => {
  pid,
  state,
  application_name AS source,
+ usename AS username,
  age(now(),xact_start) AS running_for,
+ xact_start AS transaction_start,
  wait_event IS NOT NULL AS waiting,
  query
 FROM pg_stat_activity
@@ -61,7 +63,9 @@ WHERE
  pid,
  state,
  application_name AS source,
+ usename AS username,
  age(now(),xact_start) AS running_for,
+ xact_start AS transaction_start,
  wait_event IS NOT NULL AS waiting,
  query
 FROM pg_stat_activity


### PR DESCRIPTION
Follow-up from https://github.com/heroku/heroku-pg/pull/122. 