### PR TITLE
remove existing sigint listeners

### DIFF
--- a/lib/psql.js
+++ b/lib/psql.js
@@ -42,6 +42,7 @@ function psqlInteractive (dbEnv, prompt) {
 }
 
 function handleSignals () {
+  process.removeAllListeners('SIGINT')
   process.on('SIGINT', () => {})
 }
 


### PR DESCRIPTION
note that running v6 without having it installed will cancel when running ctrl-c no matter what (seems to be something with `babel-node`) so to test this you'll need a fully installed version of v6