### PR TITLE
Use highest version of heroku-cli-addons

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "co-wait": "0.0.0",
     "debug": "2.6.3",
     "filesize": "3.5.6",
-    "heroku-cli-addons": "1.2.16",
+    "heroku-cli-addons": "1.2.20",
     "heroku-cli-util": "6.1.17",
     "lodash.capitalize": "4.2.1",
     "lodash.flatten": "4.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,9 +1089,9 @@ has-yarn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-1.0.0.tgz#89e25db604b725c8f5976fff0addc921b828a5a7"
 
-heroku-cli-addons@1.2.16:
-  version "1.2.16"
-  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.2.16.tgz#f4ef511179d2c1d46f73676e4d887f2c52d71efb"
+heroku-cli-addons@1.2.20:
+  version "1.2.20"
+  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.2.20.tgz#bfd0899916d9163a172cc1a900583143a6a08c2e"
   dependencies:
     co "4.6.0"
     co-wait "0.0.0"


### PR DESCRIPTION
Releasing this so we can fix https://trello.com/c/c6VHpmy1/2014-%5Bcreds%5D-cannot-list-credentials-and-specify-a-database-if-a-database-has-over-two-attachments-for-the-same-app.
 
This version includes the fix done in https://github.com/heroku/heroku-cli-addons/pull/80 so we can solve ambiguous resolution of postgres addons. 