### PR TITLE
Additional credentials and psql

### DIFF
--- a/commands/psql.js
+++ b/commands/psql.js
@@ -9,7 +9,9 @@ function * run (context, heroku) {
 
   const {app, args, flags} = context
 
-  let db = yield fetcher.database(app, args.database)
+  let namespace = flags.credential ? `credential:${flags.credential}` : null
+
+  let db = yield fetcher.database(app, args.database, namespace)
   cli.console.error(`--> Connecting to ${cli.color.addon(db.attachment.addon.name)}`)
   if (flags.command) {
     process.stdout.write(yield psql.exec(db, flags.command))
@@ -22,7 +24,10 @@ let cmd = {
   description: 'open a psql shell to the database',
   needsApp: true,
   needsAuth: true,
-  flags: [{name: 'command', char: 'c', description: 'SQL command to run', hasValue: true}],
+  flags: [
+    {name: 'command', char: 'c', description: 'SQL command to run', hasValue: true},
+    {name: 'credential', description: 'credential to use', hasValue: true}
+  ],
   args: [{name: 'database', optional: true}],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "co-wait": "0.0.0",
     "debug": "2.6.3",
     "filesize": "3.5.6",
-    "heroku-cli-addons": "1.2.20",
+    "heroku-cli-addons": "1.2.21",
     "heroku-cli-util": "6.1.17",
     "lodash.capitalize": "4.2.1",
     "lodash.flatten": "4.4.0",

--- a/test/lib/fetcher.js
+++ b/test/lib/fetcher.js
@@ -35,7 +35,7 @@ describe('fetcher', () => {
 
   describe('addon', () => {
     it('returns addon attached to app', () => {
-      stub.withArgs(sinon.match.any, 'myapp', 'DATABASE_URL', {addon_service: 'heroku-postgresql'}).returns(Promise.resolve({addon: {name: 'postgres-1'}}))
+      stub.withArgs(sinon.match.any, 'myapp', 'DATABASE_URL', {addon_service: 'heroku-postgresql', namespace: null}).returns(Promise.resolve({addon: {name: 'postgres-1'}}))
       return fetcher(new Heroku()).addon('myapp', 'DATABASE_URL')
       .then(addon => {
         expect(addon.name, 'to equal', 'postgres-1')
@@ -47,7 +47,7 @@ describe('fetcher', () => {
     it('returns db connection info', () => {
       let addonApp = {name: 'addon-app'}
       let app = {name: 'myapp'}
-      stub.withArgs(sinon.match.any, 'myapp', 'DATABASE_URL', {addon_service: 'heroku-postgresql'}).returns(Promise.resolve(
+      stub.withArgs(sinon.match.any, 'myapp', 'DATABASE_URL', {addon_service: 'heroku-postgresql', namespace: null}).returns(Promise.resolve(
         {addon: {id: 100, name: 'postgres-1', app: addonApp}, app, config_vars: ['DATABASE_URL']}
       ))
       api.get('/apps/myapp/config-vars').reply(200, {
@@ -60,7 +60,7 @@ describe('fetcher', () => {
     it('uses attachment db config', () => {
       let addonApp = {name: 'addon-app'}
       let attachApp = {name: 'attach-myapp'}
-      stub.withArgs(sinon.match.any, 'myapp', 'attach-myapp::DATABASE_URL', {addon_service: 'heroku-postgresql'}).returns(Promise.resolve(
+      stub.withArgs(sinon.match.any, 'myapp', 'attach-myapp::DATABASE_URL', {addon_service: 'heroku-postgresql', namespace: null}).returns(Promise.resolve(
         {addon: {id: 100, name: 'postgres-1', app: addonApp}, app: attachApp, config_vars: ['DATABASE_URL']}
       ))
       api.get('/apps/attach-myapp/config-vars').reply(200, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1089,9 +1089,9 @@ has-yarn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-1.0.0.tgz#89e25db604b725c8f5976fff0addc921b828a5a7"
 
-heroku-cli-addons@1.2.20:
-  version "1.2.20"
-  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.2.20.tgz#bfd0899916d9163a172cc1a900583143a6a08c2e"
+heroku-cli-addons@1.2.21:
+  version "1.2.21"
+  resolved "https://registry.yarnpkg.com/heroku-cli-addons/-/heroku-cli-addons-1.2.21.tgz#aa0204e1b606184e05fed7c2a951f2a31e30f934"
   dependencies:
     co "4.6.0"
     co-wait "0.0.0"


### PR DESCRIPTION
## Current situation

```
heroku pg:psql haiku -a camille-main-app
//should connect to the haiku database as default credential

heroku pg:psql haiku --credential hello -a camille-main-app
//does not exist, no credential flag supported, no way of using psql with a credential by specifying a haiku
```

```
heroku addons:attach haiku --as DEFAULT -a camille-main-app
heroku addons:attach haiku --credential hello --as HELLO -a camille-main-app
heroku pg:psql DEFAULT -a camille-main-app
// connects to the haiku database as default
heroku pg:psql HELLO -a camille-main-app
// could not find "hello" (it's being filtered as a namespaced addon)
```

## What do we want?

```
heroku pg:psql haiku -a camille-main-app
//should connect to the haiku database as default credential

heroku pg:psql haiku --credential hello -a camille-main-app
//should connect to the haiku database as hello
```

```
heroku addons:attach haiku --as DEFAULT -a camille-main-app
heroku addons:attach haiku --credential hello --as HELLO -a camille-main-app
heroku pg:psql DEFAULT -a camille-main-app
// should connect to the haiku database as default
heroku pg:psql HELLO -a camille-main-app
// should connect to the haiku database as hello
```

## How?

https://github.com/heroku/heroku-cli-addons/pull/83 has the heroku-cli-addons to make this PR then work