### PR TITLE
Deprecation warning for pg:credentials --reset

### DIFF
--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -80,6 +80,7 @@ Connection URL:
   let reset = co.wrap(function * () {
     const host = require('../lib/host')
     let db = yield fetcher.addon(app, args.database)
+    cli.warn(`${cli.color.cmd('pg:credentials --reset')} is being deprecated. Please use ${cli.color.cmd('pg:credentials:rotate')} instead.`)
     yield cli.action(`Resetting credentials on ${cli.color.addon(db.name)}`, co(function * () {
       yield heroku.post(`/client/v11/databases/${db.id}/credentials_rotation`, {host: host(db)})
     }))

--- a/test/commands/credentials.js
+++ b/test/commands/credentials.js
@@ -61,7 +61,7 @@ Connection URL:
     pg.post('/client/v11/databases/1/credentials_rotation').reply(200)
     return cmd.run({app: 'myapp', args: {}, flags: {reset: true}})
     .then(() => expect(cli.stdout, 'to equal', ''))
-    .then(() => expect(cli.stderr, 'to equal', 'Resetting credentials on postgres-1... done\n'))
+    .then(() => expect(cli.stderr, 'to contain', 'Resetting credentials on postgres-1... done\n'))
   })
 
   // Private beta behaviour


### PR DESCRIPTION
Adds a warning to prepare for eventual deprecation of pg:credentials --reset. 

```
heroku pg:credentials HEROKU_POSTGRESQL_CAMILLE_URL --reset -a camille-main-app
 ▸    pg:credentials --reset is being deprecated. Please use pg:credentials:rotate instead.
Resetting credentials on postgresql-camille-contoured-64778... done
```

https://github.com/heroku/shogun/pull/7604 needs to be merged first