### PR TITLE
Deprecation warning for pg:credentials

### DIFF
--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -69,6 +69,7 @@ function * run (context, heroku) {
       })
     } catch (err) {
       if (!err.statusCode || err.statusCode !== 422) throw err
+      cli.warn(`This version of ${cli.color.cmd('pg:credentials')} is being deprecated. Please use ${cli.color.cmd('pg:credentials:url')} instead.`)
       let db = yield fetcher.database(app, args.database)
       cli.log(`Connection info string:
    "dbname=${db.database} host=${db.host} port=${db.port || 5432} user=${db.user} password=${db.password} sslmode=require"


### PR DESCRIPTION
On credentials GA day, `pg:credentials` will have a different output. 
Let's give people a heads-up. 