### PR TITLE
When listing apps with attachments to destroy, only mention app once

### DIFF
--- a/commands/credentials/destroy.js
+++ b/commands/credentials/destroy.js
@@ -22,7 +22,8 @@ function * run (context, heroku) {
 
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   let credAttachments = attachments.filter(a => a.namespace === `credential:${flags.name}`)
-  if (credAttachments.length > 0) throw new Error(`Credential ${flags.name} must be detached from the app${credAttachments.length > 1 ? 's' : ''} ${credAttachments.map(a => cli.color.app(a.app.name)).join(', ')} before destroying.`)
+  let credAttachmentApps = Array.from(new Set(credAttachments.map(a => a.app.name)))
+  if (credAttachmentApps.length > 0) throw new Error(`Credential ${flags.name} must be detached from the app${credAttachmentApps.length > 1 ? 's' : ''} ${credAttachmentApps.map(name => cli.color.app(name)).join(', ')} before destroying.`)
 
   yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action`)
 

--- a/test/commands/credentials/destroy.js
+++ b/test/commands/credentials/destroy.js
@@ -101,4 +101,36 @@ Database objects owned by credname will be assigned to the default credential.
     const err = new Error('Credential jeff must be detached from the app otherapp before destroying.')
     return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
   })
+
+  it('only mentions an app with multiple attachments once', () => {
+    let attachments = [
+      {
+        app: {name: 'myapp'},
+        addon: {id: 100, name: 'postgres-1'},
+        config_vars: ['HEROKU_POSTGRESQL_PINK_URL']
+      },
+      {
+        app: {name: 'otherapp'},
+        addon: {id: 100, name: 'postgres-1'},
+        namespace: 'credential:jeff',
+        config_vars: ['HEROKU_POSTGRESQL_PURPLE_URL']
+      },
+      {
+        app: {name: 'otherapp'},
+        addon: {id: 100, name: 'postgres-1'},
+        namespace: 'credential:jeff',
+        config_vars: ['HEROKU_POSTGRESQL_RED_URL']
+      },
+      {
+        app: {name: 'yetanotherapp'},
+        addon: {id: 100, name: 'postgres-1'},
+        namespace: 'credential:jeff',
+        config_vars: ['HEROKU_POSTGRESQL_BLUE_URL']
+      }
+    ]
+    api.get('/addons/postgres-1/addon-attachments').reply(200, attachments)
+
+    const err = new Error('Credential jeff must be detached from the apps otherapp, yetanotherapp before destroying.')
+    return expect(cmd.run({app: 'myapp', args: {}, flags: {name: 'jeff'}}), 'to be rejected with', err)
+  })
 })


### PR DESCRIPTION
#### What does this PR do?

Defect found while running through https://salesforce.quip.com/CDofAfqPd0E8), for a credential that has been attached under multiple names for the same app, only mention the app name once. 

#### How has this been tested?

* [x] Specs
* [x] Staging

#### Did you write new tests for any new functionality or changes in behaviour?

yes

#### Any relevant links (support ticket or trello card) ?

https://trello.com/c/32plq4Tz/2046-publish-credentials-ga