### PR TITLE
Show connection count even if zero during rotation

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -54,7 +54,7 @@ function presentCredentialAttachments (app, credAttachments, credentials, cred) 
         'connections': credential.connections
       }
     })
-    let connectionInformationAvailable = formatted.some((c) => c.connections)
+    let connectionInformationAvailable = formatted.some((c) => c.connections != null)
     if (connectionInformationAvailable) {
       let prefix = '       '
       rotationLines.push(`${prefix}Usernames currently active for this credential:`)

--- a/test/commands/credentials.js
+++ b/test/commands/credentials.js
@@ -90,7 +90,7 @@ Connection URL:
         credentials: [
           {
             user: 'jeff',
-            connections: 5,
+            connections: 0,
             state: 'revoking'
           },
           {
@@ -133,7 +133,7 @@ jeff                                                                           r
  ├─ as HEROKU_POSTGRESQL_GREEN on main-app app
  └─ as HEROKU_POSTGRESQL_PINK on another-app app
        Usernames currently active for this credential:
-       jeff           waiting for no connections to be revoked  5 connections
+       jeff           waiting for no connections to be revoked  0 connections
        jeff-rotating  active                                    2 connections
 ransom                                                                         active
  └─ as HEROKU_POSTGRESQL_BLUE on yet-another-app app


### PR DESCRIPTION
#### What does this PR do?

Defect found while running through https://salesforce.quip.com/CDofAfqPd0E8), always show credential count when it is returned by the API, even if 0. 

#### How has this been tested?

* [x] Specs
* [x] Staging

#### Did you write new tests for any new functionality or changes in behaviour?

changed existing ones

#### Any relevant links (support ticket or trello card) ?

https://trello.com/c/32plq4Tz/2046-publish-credentials-ga