### PR TITLE
pg:killall terminates connections for all credentials

### DIFF
--- a/commands/killall.js
+++ b/commands/killall.js
@@ -7,7 +7,7 @@ function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const host = require('../lib/host')
 
-  yield cli.action('Terminating connections', co(function * () {
+  yield cli.action('Terminating connections for all credentials', co(function * () {
     const db = yield fetcher.addon(context.app, context.args.database)
     yield heroku.post(`/client/v11/databases/${db.id}/connection_reset`, {host: host(db)})
   }))
@@ -16,7 +16,7 @@ function * run (context, heroku) {
 module.exports = {
   topic: 'pg',
   command: 'killall',
-  description: 'terminates all connections',
+  description: 'terminates all connections for all credentials',
   needsApp: true,
   needsAuth: true,
   args: [{name: 'database', optional: true}],

--- a/test/commands/killall.js
+++ b/test/commands/killall.js
@@ -37,6 +37,6 @@ describe('pg:killall', () => {
 
     return cmd.run({app: 'myapp', args: {}, flags: {}})
       .then(() => expect(cli.stdout, 'to equal', ''))
-      .then(() => expect(cli.stderr, 'to equal', 'Terminating connections... done\n'))
+      .then(() => expect(cli.stderr, 'to equal', 'Terminating connections for all credentials... done\n'))
   })
 })


### PR DESCRIPTION
Change help text of pg:killall after https://github.com/heroku/shogun/pull/8063 makes it terminate connections across all users, not just default. 