### PR TITLE
Modify help text: only one name can be specified

### DIFF
--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -68,7 +68,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   flags: [
-    {name: 'name', char: 'n', description: 'which credentials to rotate (default credentials if not specified)', hasValue: true},
+    {name: 'name', char: 'n', description: 'which credential to rotate (default credentials if not specified)', hasValue: true},
     {name: 'all', description: 'rotate all credentials', hasValue: false},
     {name: 'confirm', char: 'c', hasValue: true},
     {name: 'force', description: 'forces rotating the targeted credentials', hasValue: false}

--- a/commands/credentials/url.js
+++ b/commands/credentials/url.js
@@ -54,7 +54,7 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   flags: [
-    {name: 'name', char: 'n', description: 'which credentials to show (default credentials if not specified)', hasValue: true}
+    {name: 'name', char: 'n', description: 'which credential to show (default credentials if not specified)', hasValue: true}
   ],
   args: [{name: 'database', optional: true}],
   run: cli.command({preauth: true}, co.wrap(run))


### PR DESCRIPTION
Changing help text to singular since only one credential can be specified through the `--name` flag. 