### PR TITLE
Allow for default credential to be forced with a warning

### DIFF
--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -10,27 +10,23 @@ function * run (context, heroku) {
   const {app, args, flags} = context
   let db = yield fetcher.addon(app, args.database)
   let all = flags.all
+  let warnings = []
 
   if (all && flags.name !== undefined) {
     throw new Error('cannot pass both --all and --name')
   }
-  let cred = flags.name || 'default'
-  if ((cred === 'default' || all) && flags.force) {
-    if (all) {
-      throw new Error('Cannot force rotate all credentials: the default credential cannot be force rotated.')
-    } else {
-      throw new Error('Cannot force rotate the default credential.')
-    }
-  }
   if (util.starterPlan(db) && cred !== 'default') {
     throw new Error(`Only one default credential is supported for Hobby tier databases.`)
+  }
+  let cred = flags.name || 'default'
+  if (all && flags.force) {
+    warnings.push('WARNING: This forces rotation on all credentials including the default credential.')
   }
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   if (flags.name) {
     attachments = attachments.filter(a => a.namespace === `credential:${cred}`)
   }
 
-  let warnings = []
   if (!flags.all) {
     warnings.push(`The password for the ${cred} credential will rotate.`)
   }

--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -20,7 +20,7 @@ function * run (context, heroku) {
     throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
   if (all && flags.force) {
-    warnings.push('WARNING: This forces rotation on all credentials including the default credential.')
+    warnings.push('This forces rotation on all credentials including the default credential.')
   }
   let attachments = yield heroku.get(`/addons/${db.name}/addon-attachments`)
   if (flags.name) {

--- a/commands/credentials/rotate.js
+++ b/commands/credentials/rotate.js
@@ -11,6 +11,7 @@ function * run (context, heroku) {
   let db = yield fetcher.addon(app, args.database)
   let all = flags.all
   let warnings = []
+  let cred = flags.name || 'default'
 
   if (all && flags.name !== undefined) {
     throw new Error('cannot pass both --all and --name')
@@ -18,7 +19,6 @@ function * run (context, heroku) {
   if (util.starterPlan(db) && cred !== 'default') {
     throw new Error(`Only one default credential is supported for Hobby tier databases.`)
   }
-  let cred = flags.name || 'default'
   if (all && flags.force) {
     warnings.push('WARNING: This forces rotation on all credentials including the default credential.')
   }

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -195,12 +195,12 @@ This command will affect the apps appname_1, appname_2, appname_3.`
     return cmd.run({app: 'myapp',
       args: {},
       flags: { all: true, force: true, confirm: 'myapp' }})
-      .then(() => {
-        expect(lastApp, 'to equal', 'myapp')
-        expect(lastConfirm, 'to equal', 'myapp')
-        expect(lastMsg, 'to equal', message)
-      })
+    .then(() => {
+      expect(lastApp, 'to equal', 'myapp')
+      expect(lastConfirm, 'to equal', 'myapp')
+      expect(lastMsg, 'to equal', message)
     })
+  })
 
   it('requires app confirmation for rotating a specific role with --name', () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -188,7 +188,7 @@ This command will affect the apps appname_1, appname_2, appname_3.`
     pg.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
 
     const message = `WARNING: Destructive Action
-WARNING: This forces rotation on all credentials including the default credential.
+This forces rotation on all credentials including the default credential.
 Connections will be reset and applications will be restarted.
 This command will affect the apps appname_1, appname_2, appname_3.`
 

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -196,11 +196,11 @@ This command will affect the apps appname_1, appname_2, appname_3.`
       args: {},
       flags: { all: true, force: true, confirm: 'myapp' }})
       .then(() => {
-      expect(lastApp, 'to equal', 'myapp')
-      expect(lastConfirm, 'to equal', 'myapp')
-      expect(lastMsg, 'to equal', message)
+        expect(lastApp, 'to equal', 'myapp')
+        expect(lastConfirm, 'to equal', 'myapp')
+        expect(lastMsg, 'to equal', message)
+      })
     })
-  })
 
   it('requires app confirmation for rotating a specific role with --name', () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -188,9 +188,9 @@ This command will affect the apps appname_1, appname_2, appname_3.`
     pg.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
 
     const message = `WARNING: Destructive Action
-    WARNING: This forces rotation on all credentials including the default credential.
-    Connections will be reset and applications will be restarted.
-    This command will affect the apps appname_1, appname_2, appname_3.`
+WARNING: This forces rotation on all credentials including the default credential.
+Connections will be reset and applications will be restarted.
+This command will affect the apps appname_1, appname_2, appname_3.`
 
     return cmd.run({app: 'myapp',
       args: {},

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -100,16 +100,6 @@ describe('pg:credentials:rotate', () => {
     return expect(cmd.run({app: 'myapp', args: {}, flags: {all: true, name: 'my_role', confirm: 'myapp'}}), 'to be rejected with', err)
   })
 
-  it('fails with an error if both --force and --all are included', () => {
-    const err = new Error(`Cannot force rotate all credentials: the default credential cannot be force rotated.`)
-    return expect(cmd.run({app: 'myapp', args: {}, flags: {force: true, all: true, confirm: 'myapp'}}), 'to be rejected with', err)
-  })
-
-  it('fails with an error if both --name default and --force are included', () => {
-    const err = new Error(`Cannot force rotate the default credential.`)
-    return expect(cmd.run({app: 'myapp', args: {}, flags: {force: true, name: 'default', confirm: 'myapp'}}), 'to be rejected with', err)
-  })
-
   it('throws an error when the db is starter plan but the name is specified', () => {
     const hobbyAddon = {
       name: 'postgres-1',

--- a/test/commands/credentials/rotate.js
+++ b/test/commands/credentials/rotate.js
@@ -184,6 +184,24 @@ This command will affect the apps appname_1, appname_2, appname_3.`
     })
   })
 
+  it('requires app confirmation for rotating all roles with --all and --force', () => {
+    pg.post('/postgres/v0/databases/postgres-1/credentials_rotation').reply(200)
+
+    const message = `WARNING: Destructive Action
+    WARNING: This forces rotation on all credentials including the default credential.
+    Connections will be reset and applications will be restarted.
+    This command will affect the apps appname_1, appname_2, appname_3.`
+
+    return cmd.run({app: 'myapp',
+      args: {},
+      flags: { all: true, force: true, confirm: 'myapp' }})
+      .then(() => {
+      expect(lastApp, 'to equal', 'myapp')
+      expect(lastConfirm, 'to equal', 'myapp')
+      expect(lastMsg, 'to equal', message)
+    })
+  })
+
   it('requires app confirmation for rotating a specific role with --name', () => {
     pg.post('/postgres/v0/databases/postgres-1/credentials/my_role/credentials_rotation').reply(200)
 


### PR DESCRIPTION
Given the new functionality and flexibility desired with Credentials as a whole, this is to allow maintenances for DBs to run more smoothly and help expedite those types of maintenance works as well.