### PR TITLE
[blocked] Throw an error if --reset is used

### DIFF
--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -42,12 +42,7 @@ function * run (context, heroku) {
   })
 
   let reset = co.wrap(function * () {
-    const host = require('../lib/host')
-    let db = yield fetcher.addon(app, args.database)
-    cli.warn(`${cli.color.cmd('pg:credentials --reset')} is being deprecated. Please use ${cli.color.cmd('pg:credentials:rotate')} instead.`)
-    yield cli.action(`Resetting credentials on ${cli.color.addon(db.name)}`, co(function * () {
-      yield heroku.post(`/client/v11/databases/${db.id}/credentials_rotation`, {host: host(db)})
-    }))
+    cli.error(`${cli.color.cmd('pg:credentials --reset')} has been deprecated. Please use ${cli.color.cmd('pg:credentials:rotate')} instead.`)
   })
 
   if (flags.reset) {

--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -58,7 +58,7 @@ module.exports = {
   description: 'show information on credentials in the database',
   needsApp: true,
   needsAuth: true,
-  flags: [{name: 'reset', description: 'reset database credentials'}],
+  flags: [{name: 'reset', description: 'deprecated'}],
   args: [{name: 'database', optional: true}],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/test/commands/credentials.js
+++ b/test/commands/credentials.js
@@ -45,11 +45,13 @@ describe('pg:credentials', () => {
     api.done()
   })
 
-  it('resets credentials', () => {
-    pg.post('/client/v11/databases/1/credentials_rotation').reply(200)
+  it('errors if --reset is used', () => {
     return cmd.run({app: 'myapp', args: {}, flags: {reset: true}})
-    .then(() => expect(cli.stdout, 'to equal', ''))
-    .then(() => expect(cli.stderr, 'to contain', 'Resetting credentials on postgres-1... done\n'))
+      .catch(err => {
+        if (err.code !== 1) throw err
+        expect(cli.stdout, 'to equal', '')
+        expect(cli.stderr, 'to equal', ' ▸    this is an error message\n')
+      })
   })
 
   it('shows the correct credentials', () => {


### PR DESCRIPTION
We are deprecating `pg:credentials --reset`. If on Monday, still no tombstones have been hit in shogun for that command (so far none), we should take this step towards full deprecation. 