### PR TITLE
Promote: make it work with credentials

### DIFF
--- a/commands/promote.js
+++ b/commands/promote.js
@@ -17,8 +17,6 @@ function * run (context, heroku) {
     // If no current DATABASE, return nil.
     let attachments = yield heroku.get(`/apps/${app}/addon-attachments`)
     let current = attachments.find(a => a.name === 'DATABASE')
-    console.log(current)
-    console.log(attachment)
     if (!current) return
     if (current.addon.name === attachment.addon.name && current.namespace === attachment.namespace) {
       if (attachment.namespace) {

--- a/commands/promote.js
+++ b/commands/promote.js
@@ -6,7 +6,7 @@ const co = require('co')
 function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   const {app, args} = context
-  const db = yield fetcher.addon(app, args.database)
+  const attachment = yield fetcher.attachment(app, args.database)
 
   yield cli.action(`Ensuring an alternate alias for existing ${cli.color.configVar('DATABASE_URL')}`, co(function * () {
     // Finds or creates a non-DATABASE attachment for the DB currently
@@ -17,9 +17,17 @@ function * run (context, heroku) {
     // If no current DATABASE, return nil.
     let attachments = yield heroku.get(`/apps/${app}/addon-attachments`)
     let current = attachments.find(a => a.name === 'DATABASE')
+    console.log(current)
+    console.log(attachment)
     if (!current) return
-    if (current.addon.name === db.name) throw new Error(`${cli.color.addon(db.name)} is already promoted on ${cli.color.app(app)}`)
-    let existing = attachments.filter(a => a.addon.id === current.addon.id).find(a => a.name !== 'DATABASE')
+    if (current.addon.name === attachment.addon.name && current.namespace === attachment.namespace) {
+      if (attachment.namespace) {
+        throw new Error(`${cli.color.attachment(attachment.name)} is already promoted on ${cli.color.app(app)}`)
+      } else {
+        throw new Error(`${cli.color.addon(attachment.addon.name)} is already promoted on ${cli.color.app(app)}`)
+      }
+    }
+    let existing = attachments.filter(a => a.addon.id === current.addon.id && a.namespace === current.namespace).find(a => a.name !== 'DATABASE')
     if (existing) return cli.action.done(cli.color.configVar(existing.name + '_URL'))
 
     // The current add-on occupying the DATABASE attachment has no
@@ -30,18 +38,27 @@ function * run (context, heroku) {
       body: {
         app: {name: app},
         addon: {name: current.addon.name},
+        namespace: current.namespace,
         confirm: app
       }
     })
     cli.action.done(cli.color.configVar(backup.name + '_URL'))
   }))
 
-  yield cli.action(`Promoting ${cli.color.addon(db.name)} to ${cli.color.configVar('DATABASE_URL')} on ${cli.color.app(app)}`, co(function * () {
+  let promotionMessage
+  if (attachment.namespace) {
+    promotionMessage = `Promoting ${cli.color.attachment(attachment.name)} to ${cli.color.configVar('DATABASE_URL')} on ${cli.color.app(app)}`
+  } else {
+    promotionMessage = `Promoting ${cli.color.addon(attachment.addon.name)} to ${cli.color.configVar('DATABASE_URL')} on ${cli.color.app(app)}`
+  }
+
+  yield cli.action(promotionMessage, co(function * () {
     yield heroku.post('/addon-attachments', {
       body: {
         name: 'DATABASE',
         app: {name: app},
-        addon: {name: db.name},
+        addon: {name: attachment.addon.name},
+        namespace: attachment.namespace,
         confirm: app
       }
     })

--- a/test/commands/promote.js
+++ b/test/commands/promote.js
@@ -32,7 +32,7 @@ describe('pg:promote', () => {
     api.done()
   })
 
-  it('promotes db', () => {
+  it('promotes db and creates another attachment if current DATABASE does not have another', () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       {name: 'DATABASE', addon: {name: 'postgres-2'}}
     ])
@@ -41,6 +41,23 @@ describe('pg:promote', () => {
       addon: {name: 'postgres-2'},
       confirm: 'myapp'
     }).reply(201, {name: 'RED'})
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting postgres-1 to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('promotes db and creates another attachment if current DATABASE does not have another', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'DATABASE', addon: {name: 'postgres-2'}},
+      {name: 'PURPLE', addon: {name: 'postgres-2'}}
+    ])
     api.post('/addon-attachments', {
       name: 'DATABASE',
       app: {name: 'myapp'},

--- a/test/commands/promote.js
+++ b/test/commands/promote.js
@@ -6,20 +6,104 @@ const expect = require('unexpected')
 const nock = require('nock')
 const proxyquire = require('proxyquire')
 
-const addon = {
-  name: 'postgres-1'
-}
-const fetcher = () => {
-  return {
-    addon: () => addon
-  }
-}
+describe('pg:promote when argument is database', () => {
+  let api
 
-const cmd = proxyquire('../../commands/promote', {
-  '../lib/fetcher': fetcher
+  const attachment = {
+    addon: {
+      name: 'postgres-1'
+    },
+    namespace: null
+  }
+
+  const fetcher = () => {
+    return {
+      attachment: () => attachment
+    }
+  }
+
+  const cmd = proxyquire('../../commands/promote', {
+    '../lib/fetcher': fetcher
+  })
+
+  beforeEach(() => {
+    api = nock('https://api.heroku.com:443')
+    cli.mockConsole()
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    api.done()
+  })
+
+  it('promotes the db and creates another attachment if current DATABASE does not have another', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'DATABASE', addon: {name: 'postgres-2'}, namespace: null}
+    ])
+    api.post('/addon-attachments', {
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-2'},
+      namespace: null,
+      confirm: 'myapp'
+    }).reply(201, {name: 'RED'})
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: null,
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting postgres-1 to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('promotes the db and does not create another attachment if current DATABASE has another', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'DATABASE', addon: {name: 'postgres-2'}, namespace: null},
+      {name: 'PURPLE', addon: {name: 'postgres-2'}, namespace: null}
+    ])
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: null,
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... PURPLE_URL
+Promoting postgres-1 to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('does not promote the db if is already is DATABASE', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'DATABASE', addon: {name: 'postgres-1'}, namespace: null},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: null}
+    ])
+    const err = new Error(`postgres-1 is already promoted on myapp`)
+    return expect(cmd.run({app: 'myapp', args: {}, flags: {}}), 'to be rejected with', err)
+  })
 })
 
-describe('pg:promote when argument is database', () => {
+describe('pg:promote when argument is a credential attachment', () => {
+  const credentialAttachment = {
+    name: 'PURPLE',
+    addon: {name: 'postgres-1'},
+    namespace: 'credential:hello'
+  }
+
+  const fetcher = () => {
+    return {
+      attachment: () => credentialAttachment
+    }
+  }
+
+  const cmd = proxyquire('../../commands/promote', {
+    '../lib/fetcher': fetcher
+  })
+
   let api
 
   beforeEach(() => {
@@ -32,9 +116,10 @@ describe('pg:promote when argument is database', () => {
     api.done()
   })
 
-  it('promotes db and creates another attachment if current DATABASE does not have another', () => {
+  it('promotes the credential and creates another attachment if current DATABASE does not have another', () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
-      {name: 'DATABASE', addon: {name: 'postgres-2'}}
+      {name: 'DATABASE', addon: {name: 'postgres-2'}},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'}
     ])
     api.post('/addon-attachments', {
       app: {name: 'myapp'},
@@ -45,37 +130,122 @@ describe('pg:promote when argument is database', () => {
       name: 'DATABASE',
       app: {name: 'myapp'},
       addon: {name: 'postgres-1'},
+      namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
     return cmd.run({app: 'myapp', args: {}, flags: {}})
     .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
-Promoting postgres-1 to DATABASE_URL on myapp... done
+Promoting PURPLE to DATABASE_URL on myapp... done
 `))
   })
 
-  it('promotes db and does not create another attachment if current DATABASE has another', () => {
+  it('promotes the credential and creates another attachment if current DATABASE does not have another and current DATABASE is a credential', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'},
+      {name: 'DATABASE', addon: {name: 'postgres-1'}, namespace: 'credential:goodbye'}
+    ])
+    api.post('/addon-attachments', {
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: 'credential:goodbye',
+      confirm: 'myapp'
+    }).reply(201, {name: 'RED'})
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: 'credential:hello',
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting PURPLE to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('promotes the credential and does not create another attachment if current DATABASE has another', () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
       {name: 'DATABASE', addon: {name: 'postgres-2'}},
-      {name: 'PURPLE', addon: {name: 'postgres-2'}}
+      {name: 'BLUE', addon: {name: 'postgres-2'}},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'}
     ])
     api.post('/addon-attachments', {
       name: 'DATABASE',
       app: {name: 'myapp'},
       addon: {name: 'postgres-1'},
+      namespace: 'credential:hello',
       confirm: 'myapp'
     }).reply(201)
     return cmd.run({app: 'myapp', args: {}, flags: {}})
-    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... PURPLE_URL
-Promoting postgres-1 to DATABASE_URL on myapp... done
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... BLUE_URL
+Promoting PURPLE to DATABASE_URL on myapp... done
 `))
   })
 
-  it('does not promote the db if is already is DATABASE', () => {
+  it('promotes the credential if the current promoted database is for the same addon, but the default credential', () => {
     api.get('/apps/myapp/addon-attachments').reply(200, [
-      {name: 'DATABASE', addon: {name: 'postgres-1'}},
-      {name: 'PURPLE', addon: {name: 'postgres-1'}}
+      {name: 'DATABASE', addon: {name: 'postgres-1'}, namespace: null},
+      {name: 'RED', addon: {name: 'postgres-1'}, namespace: null},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'}
     ])
-    const err = new Error(`postgres-1 is already promoted on myapp`)
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: 'credential:hello',
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting PURPLE to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('promotes the credential if the current promoted database is for the same addon, but the default credential', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'DATABASE', addon: {name: 'postgres-1'}, namespace: null},
+      {name: 'RED', addon: {name: 'postgres-1'}, namespace: null},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'}
+    ])
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: 'credential:hello',
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting PURPLE to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('promotes the credential if the current promoted database is for the same addon, but another credential', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'DATABASE', addon: {name: 'postgres-1'}, namespace: 'credential:goodbye'},
+      {name: 'RED', addon: {name: 'postgres-1'}, namespace: 'credential:goodbye'},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'}
+    ])
+    api.post('/addon-attachments', {
+      name: 'DATABASE',
+      app: {name: 'myapp'},
+      addon: {name: 'postgres-1'},
+      namespace: 'credential:hello',
+      confirm: 'myapp'
+    }).reply(201)
+    return cmd.run({app: 'myapp', args: {}, flags: {}})
+    .then(() => expect(cli.stderr, 'to equal', `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
+Promoting PURPLE to DATABASE_URL on myapp... done
+`))
+  })
+
+  it('does not promote the credential if it already is DATABASE', () => {
+    api.get('/apps/myapp/addon-attachments').reply(200, [
+      {name: 'RED', addon: {name: 'postgres-1'}, namespace: null},
+      {name: 'DATABASE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'},
+      {name: 'PURPLE', addon: {name: 'postgres-1'}, namespace: 'credential:hello'}
+    ])
+    const err = new Error(`PURPLE is already promoted on myapp`)
     return expect(cmd.run({app: 'myapp', args: {}, flags: {}}), 'to be rejected with', err)
   })
 })


### PR DESCRIPTION
pg:promote could not be used with a credential currently and trying to do so fails with an unhelpful error message, or appeared like it had worked but had actually attached the default credential of that addon. 

This PR corrects that. 

https://trello.com/c/D2wFNu3p/2223-pgpromote-make-it-work-with-credentials