### PR TITLE
Add confirmation and warning for DBs with continuous protection

### DIFF
--- a/commands/backups/capture.js
+++ b/commands/backups/capture.js
@@ -24,7 +24,7 @@ function * run (context, heroku) {
   if (dbInfo) {
     let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
     if (dbProtected) {
-      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.  Are you sure?')
+      cli.warn(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
     }
   }
 

--- a/commands/backups/capture.js
+++ b/commands/backups/capture.js
@@ -25,7 +25,6 @@ function * run (context, heroku) {
       if (err.statusCode !== 404) throw err
       cli.exit(1, `${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
     })
-    console.log(dbInfo.info)
     if (dbInfo) {
       let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
       if (dbProtected) {

--- a/commands/backups/capture.js
+++ b/commands/backups/capture.js
@@ -18,13 +18,13 @@ function * run (context, heroku) {
     path: `/client/v11/databases/${db.id}`
   }).catch(err => {
     if (err.statusCode !== 404) throw err
-    cli.warn(`${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
+    cli.exit(1, `${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
   })
 
   if (dbInfo) {
     let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
     if (dbProtected) {
-      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. Are you sure?')
+      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.  Are you sure?')
     }
   }
 

--- a/commands/backups/capture.js
+++ b/commands/backups/capture.js
@@ -28,7 +28,8 @@ function * run (context, heroku) {
     if (dbInfo) {
       let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
       if (dbProtected) {
-        cli.warn('Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
+        cli.warn('Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail.')
+        cli.warn('See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
       }
     }
     let backup

--- a/commands/backups/capture.js
+++ b/commands/backups/capture.js
@@ -25,10 +25,11 @@ function * run (context, heroku) {
       if (err.statusCode !== 404) throw err
       cli.exit(1, `${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
     })
+    console.log(dbInfo.info)
     if (dbInfo) {
       let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
       if (dbProtected) {
-        cli.warn(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
+        cli.warn('Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
       }
     }
     let backup

--- a/commands/backups/schedule.js
+++ b/commands/backups/schedule.js
@@ -41,6 +41,22 @@ function * run (context, heroku) {
 
   let at = cli.color.cyan(`${schedule.hour}:00 ${schedule.timezone}`)
 
+  let dbInfo = yield heroku.request({
+    host: host(db),
+    method: 'get',
+    path: `/client/v11/databases/${db.id}`
+  }).catch(err => {
+    if (err.statusCode !== 404) throw err
+    cli.warn(`${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
+  })
+
+  if (dbInfo) {
+    let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
+    if (dbProtected) {
+      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. Are you sure?')
+    }
+  }
+
   yield cli.action(`Scheduling automatic daily backups of ${cli.color.addon(db.name)} at ${at}`, co(function * () {
     schedule.schedule_name = util.getUrl(attachment.config_vars)
 
@@ -61,7 +77,8 @@ module.exports = {
     {name: 'database', optional: true}
   ],
   flags: [
-    {name: 'at', required: true, hasValue: true, description: "at a specific (24h) hour in the given timezone. Defaults to UTC. --at '[HOUR]:00 [TIMEZONE]'"}
+    {name: 'at', required: true, hasValue: true, description: "at a specific (24h) hour in the given timezone. Defaults to UTC. --at '[HOUR]:00 [TIMEZONE]'"},
+    {name: 'confirm', char: 'c', hasValue: true}
   ],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/commands/backups/schedule.js
+++ b/commands/backups/schedule.js
@@ -47,13 +47,13 @@ function * run (context, heroku) {
     path: `/client/v11/databases/${db.id}`
   }).catch(err => {
     if (err.statusCode !== 404) throw err
-    cli.warn(`${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
+    cli.exit(1, `${cli.color.addon(db.name)} is not yet provisioned.\nRun ${cli.color.cmd('heroku addons:wait')} to wait until the db is provisioned.`)
   })
 
   if (dbInfo) {
     let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
     if (dbProtected) {
-      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. Are you sure?')
+      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres. Are you sure?')
     }
   }
 

--- a/commands/backups/schedule.js
+++ b/commands/backups/schedule.js
@@ -53,7 +53,7 @@ function * run (context, heroku) {
   if (dbInfo) {
     let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
     if (dbProtected) {
-      yield cli.confirmApp(app, flags.confirm, 'Continuous protection is already enabled for this database. Logical backups of large databases are likely to timeout. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres. Are you sure?')
+      cli.warn('Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
     }
   }
 

--- a/commands/backups/schedule.js
+++ b/commands/backups/schedule.js
@@ -53,7 +53,8 @@ function * run (context, heroku) {
   if (dbInfo) {
     let dbProtected = /On/.test(dbInfo.info.find(attribute => attribute.name === 'Continuous Protection').values[0])
     if (dbProtected) {
-      cli.warn('Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail. See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
+      cli.warn('Continuous protection is already enabled for this database. Logical backups of large databases are likely to fail.')
+      cli.warn('See https://devcenter.heroku.com/articles/heroku-postgres-data-safety-and-continuous-protection#physical-backups-on-heroku-postgres.')
     }
   }
 

--- a/test/commands/backups/capture.js
+++ b/test/commands/backups/capture.js
@@ -50,14 +50,14 @@ const shouldCapture = function (cmdRun) {
 
     cli.mockConsole()
 
-    return cmdRun({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
+    return cmdRun({app: 'myapp', args: {}, flags: {}})
     .then(() => expect(cli.stdout, 'to equal', `
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
 Stop a running backup with heroku pg:backups:cancel.
 
 `))
-    .then(() => expect(cli.stderr, 'to equal', `Starting backup of postgres-1... done\n${captureText()}`))
+    .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done\n${captureText()}`)))
   })
 
   it('captures a db (verbose)', () => {
@@ -84,7 +84,7 @@ Stop a running backup with heroku pg:backups:cancel.
 
     cli.mockConsole()
 
-    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true, confirm: 'myapp'}})
+    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true}})
     .then(() => expect(cli.stdout, 'to equal', `
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
@@ -93,8 +93,8 @@ Stop a running backup with heroku pg:backups:cancel.
 Backing up DATABASE to b005...
 100 log message 1
 `))
-    .then(() => expect(cli.stderr, 'to equal', `Starting backup of postgres-1... done
-`))
+    .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
+`)))
   })
 
   it('captures a db (verbose) with non billing app', () => {
@@ -121,7 +121,7 @@ Backing up DATABASE to b005...
 
     cli.mockConsole()
 
-    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true, confirm: 'myapp'}})
+    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true}})
     .then(() => expect(cli.stdout, 'to equal', `
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
@@ -133,8 +133,8 @@ Use heroku pg:backups -a mybillingapp to check the list of backups.
 Backing up DATABASE to b005...
 100 log message 1
 `))
-    .then(() => expect(cli.stderr, 'to equal', `Starting backup of postgres-1... done
-`))
+    .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
+`)))
   })
 }
 

--- a/test/commands/backups/capture.js
+++ b/test/commands/backups/capture.js
@@ -42,9 +42,15 @@ const shouldCapture = function (cmdRun) {
       finished_at: '101',
       succeeded: true
     })
+
+    let dbA = {info: [
+      {name: 'Continuous Protection', values: ['On']}
+    ]}
+    pg.get('/client/v11/databases/1').reply(200, dbA)
+
     cli.mockConsole()
 
-    return cmdRun({app: 'myapp', args: {}, flags: {}})
+    return cmdRun({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', `
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
@@ -70,9 +76,15 @@ Stop a running backup with heroku pg:backups:cancel.
       succeeded: true,
       logs: [{created_at: '100', message: 'log message 1'}]
     })
+
+    let dbA = {info: [
+      {name: 'Continuous Protection', values: ['On']}
+    ]}
+    pg.get('/client/v11/databases/1').reply(200, dbA)
+
     cli.mockConsole()
 
-    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true}})
+    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true, confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', `
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.
@@ -101,9 +113,15 @@ Backing up DATABASE to b005...
       succeeded: true,
       logs: [{created_at: '100', message: 'log message 1'}]
     })
+
+    let dbA = {info: [
+      {name: 'Continuous Protection', values: ['On']}
+    ]}
+    pg.get('/client/v11/databases/1').reply(200, dbA)
+
     cli.mockConsole()
 
-    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true}})
+    return cmdRun({app: 'myapp', args: {}, flags: {verbose: true, confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', `
 Use Ctrl-C at any time to stop monitoring progress; the backup will continue running.
 Use heroku pg:backups:info to check progress.

--- a/test/commands/backups/capture.js
+++ b/test/commands/backups/capture.js
@@ -58,6 +58,7 @@ Stop a running backup with heroku pg:backups:cancel.
 
 `))
     .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done\n${captureText()}`)))
+    .then(() => expect(cli.stderr, 'to match', new RegExp(`backups of large databases are likely to fail`)))
   })
 
   it('captures a db (verbose)', () => {
@@ -78,7 +79,7 @@ Stop a running backup with heroku pg:backups:cancel.
     })
 
     let dbA = {info: [
-      {name: 'Continuous Protection', values: ['On']}
+      {name: 'Continuous Protection', values: ['Off']}
     ]}
     pg.get('/client/v11/databases/1').reply(200, dbA)
 
@@ -94,7 +95,7 @@ Backing up DATABASE to b005...
 100 log message 1
 `))
     .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
-`)))
+`))).then(() => expect(cli.stderr, 'not to match', new RegExp(`backups of large databases are likely to fail`)))
   })
 
   it('captures a db (verbose) with non billing app', () => {
@@ -134,7 +135,7 @@ Backing up DATABASE to b005...
 100 log message 1
 `))
     .then(() => expect(cli.stderr, 'to match', new RegExp(`Starting backup of postgres-1... done
-`)))
+`))).then(() => expect(cli.stderr, 'to match', new RegExp(`backups of large databases are likely to fail`)))
   })
 
   it('captures a snapshot if called with the --snapshot flag', () => {
@@ -144,6 +145,7 @@ Backing up DATABASE to b005...
 
     pg = nock('https://postgres-api.heroku.com')
     pg.post('/postgres/v0/databases/1/snapshots').reply(200, {})
+
     cli.mockConsole()
 
     return cmdRun({app: 'myapp', args: {}, flags: {snapshot: true}})

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -25,9 +25,6 @@ const shouldSchedule = function (cmdRun) {
     ])
 
     let dbA = {info: [
-      {name: 'Plan', values: ['Hobby-dev']},
-      {name: 'Empty', values: []},
-      {name: 'Following', resolve_db_name: true, values: ['postgres://ec2-54-111-111-1.compute-1.amazonaws.com:5452/dxxxxxxxxxxxx']},
       {name: 'Continuous Protection', values: ['On']}
     ]}
     pg = nock('https://postgres-api.heroku.com')

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -51,7 +51,6 @@ const shouldSchedule = function (cmdRun) {
     let dbA = {info: [
       {name: 'Continuous Protection', values: ['On']}
     ]}
-    pg = nock('https://postgres-api.heroku.com')
     pg.get('/client/v11/databases/1').reply(200, dbA)
 
     return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})
@@ -62,7 +61,6 @@ const shouldSchedule = function (cmdRun) {
     let dbA = {info: [
       {name: 'Continuous Protection', values: ['Off']}
     ]}
-    // pg = nock('https://postgres-api.heroku.com')
     pg.get('/client/v11/databases/1').reply(200, dbA)
 
     return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -23,12 +23,10 @@ const shouldSchedule = function (cmdRun) {
         ]
       }
     ])
-
-    let dbA = {info: [
-      {name: 'Continuous Protection', values: ['On']}
-    ]}
     pg = nock('https://postgres-api.heroku.com')
-    pg.get('/client/v11/databases/1').reply(200, dbA)
+    pg.post('/client/v11/databases/1/transfer-schedules', {
+      'hour': '06', 'timezone': 'America/New_York', 'schedule_name': 'DATABASE_URL'
+    }).reply(201)
 
     cli.mockConsole()
   })
@@ -40,12 +38,35 @@ const shouldSchedule = function (cmdRun) {
   })
 
   it('schedules a backup', () => {
-    pg.post('/client/v11/databases/1/transfer-schedules', {
-      'hour': '06', 'timezone': 'America/New_York', 'schedule_name': 'DATABASE_URL'
-    }).reply(201)
+    let dbA = {info: [
+      {name: 'Continuous Protection', values: ['On']}
+    ]}
+    pg.get('/client/v11/databases/1').reply(200, dbA)
     return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT', confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', ''))
     .then(() => expect(cli.stderr, 'to match', /Scheduling automatic daily backups of postgres-1 at 06:00 America\/New_York... done\n/))
+  })
+
+  it('warns user that logical backups are error prone if continuous proctecion is on', () => {
+    let dbA = {info: [
+      {name: 'Continuous Protection', values: ['On']}
+    ]}
+    pg = nock('https://postgres-api.heroku.com')
+    pg.get('/client/v11/databases/1').reply(200, dbA)
+
+    return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})
+    .then(() => expect(cli.stderr, 'to match', /backups of large databases are likely to fail/))
+  })
+
+  it('does not warn user that logical backups are error prone if continuous proctecion is off', () => {
+    let dbA = {info: [
+      {name: 'Continuous Protection', values: ['Off']}
+    ]}
+    // pg = nock('https://postgres-api.heroku.com')
+    pg.get('/client/v11/databases/1').reply(200, dbA)
+
+    return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})
+    .then(() => expect(cli.stderr, 'not to match', /backups of large databases are likely to fail/))
   })
 }
 

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -45,7 +45,7 @@ const shouldSchedule = function (cmdRun) {
     }).reply(201)
     return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT', confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', ''))
-    .then(() => expect(cli.stderr, 'to equal', 'Scheduling automatic daily backups of postgres-1 at 06:00 America/New_York... done\n'))
+    .then(() => expect(cli.stderr, 'to match', /Scheduling automatic daily backups of postgres-1 at 06:00 America\/New_York... done\n/))
   })
 }
 

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -23,7 +23,16 @@ const shouldSchedule = function (cmdRun) {
         ]
       }
     ])
+
+    let dbA = {info: [
+      {name: 'Plan', values: ['Hobby-dev']},
+      {name: 'Empty', values: []},
+      {name: 'Following', resolve_db_name: true, values: ['postgres://ec2-54-111-111-1.compute-1.amazonaws.com:5452/dxxxxxxxxxxxx']},
+      {name: 'Continuous Protection', values: ['On']}
+    ]}
     pg = nock('https://postgres-api.heroku.com')
+    pg.get('/client/v11/databases/1').reply(200, dbA)
+
     cli.mockConsole()
   })
 
@@ -37,7 +46,7 @@ const shouldSchedule = function (cmdRun) {
     pg.post('/client/v11/databases/1/transfer-schedules', {
       'hour': '06', 'timezone': 'America/New_York', 'schedule_name': 'DATABASE_URL'
     }).reply(201)
-    return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT'}})
+    return cmdRun({app: 'myapp', args: {}, flags: {at: '06:00 EDT', confirm: 'myapp'}})
     .then(() => expect(cli.stdout, 'to equal', ''))
     .then(() => expect(cli.stderr, 'to equal', 'Scheduling automatic daily backups of postgres-1 at 06:00 America/New_York... done\n'))
   })


### PR DESCRIPTION
If a database has continuous protection, then we warn the user that logical backups are not
necessary and that backups of large databases may timeout.