### PR TITLE
Make PGSSLMODE overrideable

### DIFF
--- a/lib/bastion.js
+++ b/lib/bastion.js
@@ -26,10 +26,9 @@ exports.getBastion = getBastion
 
 const env = function (db) {
   let baseEnv = Object.assign({
-    PGAPPNAME: 'psql non-interactive'
-  }, process.env, {
-    PGSSLMODE: (!db.hostname || db.hostname === 'localhost') ? 'prefer' : 'require'
-  })
+    PGAPPNAME: 'psql non-interactive',
+    PGSSLMODE: (!db.hostname || db.hostname === 'localhost') ? 'prefer' : 'require',
+  }, process.env)
   let mapping = {
     PGUSER: 'user',
     PGPASSWORD: 'password',


### PR DESCRIPTION
All `PG*` environment variables can be overridden when using `pg:pull`
or `pg:push` since #97, except `PGSSLMODE`, probably because there was
no obvious use case to let users decide to insecurely bypass SSL.

But when using a PostgreSQL server in Docker Comnpose using the
official Postgres image, it's usually hosted on a different
container than the user app and can be reached through Docker virtual
network, and thus (rightously) considered remote.

Unfortunately, the official Postgres image does not support SSL.

It seems like a use case where it is safe to bypass SSL, even though
the server is considered remote. And it might be a growing use case
since even the official Postgres image do not intend to support SSL:
https://github.com/docker-library/postgres/pull/152

Thus I'd love to be able to use `pg:pull` from my app container to
load a database in a PG server in another container :heart_eyes: