### PR TITLE
Bump node to the version currently in use in the CLI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
 
 machine:
   node:
-    version: v7.10.0
+    version: v9.4.0
 
 test:
   post:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "heroku-client": "^3.0.2",
     "mocha": "^3.4.2",
-    "nock": "^9.0.13",
+    "nock": "9.1.6",
     "np": "^2.16.0",
     "nyc": "^11.0.3",
     "proxyquire": "^1.8.0",

--- a/test/commands/backups/capture.js
+++ b/test/commands/backups/capture.js
@@ -70,7 +70,7 @@ Stop a running backup with heroku pg:backups:cancel.
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
+      addon_service: 'heroku-postgresql'
     }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
@@ -111,7 +111,7 @@ Backing up DATABASE to b005...
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
+      addon_service: 'heroku-postgresql'
     }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
@@ -155,7 +155,7 @@ Backing up DATABASE to b005...
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
+      addon_service: 'heroku-postgresql'
     }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')

--- a/test/commands/backups/capture.js
+++ b/test/commands/backups/capture.js
@@ -30,8 +30,11 @@ const shouldCapture = function (cmdRun) {
   it('captures a db', () => {
     addon.app.name = 'myapp'
     api = nock('https://api.heroku.com')
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
-
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql'
+    }).reply(200, [{addon}])
     pg = nock('https://postgres-api.heroku.com')
     pg.post('/client/v11/databases/1/backups').reply(200, {
       num: 5,
@@ -64,7 +67,11 @@ Stop a running backup with heroku pg:backups:cancel.
   it('captures a db (verbose)', () => {
     addon.app.name = 'myapp'
     api = nock('https://api.heroku.com')
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
     pg.post('/client/v11/databases/1/backups').reply(200, {
@@ -101,7 +108,11 @@ Backing up DATABASE to b005...
   it('captures a db (verbose) with non billing app', () => {
     addon.app.name = 'mybillingapp'
     api = nock('https://api.heroku.com')
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
     pg.post('/client/v11/databases/1/backups').reply(200, {
@@ -141,7 +152,11 @@ Backing up DATABASE to b005...
   it('captures a snapshot if called with the --snapshot flag', () => {
     addon.app.name = 'mybillingapp'
     api = nock('https://api.heroku.com')
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
     pg.post('/postgres/v0/databases/1/snapshots').reply(200, {})

--- a/test/commands/backups/restore.js
+++ b/test/commands/backups/restore.js
@@ -19,7 +19,11 @@ const shouldRestore = function (cmdRun) {
 
   beforeEach(() => {
     api = nock('https://api.heroku.com')
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [{addon}])
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')
     cli.mockConsole()

--- a/test/commands/backups/restore.js
+++ b/test/commands/backups/restore.js
@@ -22,7 +22,7 @@ const shouldRestore = function (cmdRun) {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
+      addon_service: 'heroku-postgresql'
     }).reply(200, [{addon}])
 
     pg = nock('https://postgres-api.heroku.com')

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -14,7 +14,7 @@ const shouldSchedule = function (cmdRun) {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
+      addon_service: 'heroku-postgresql'
     }).reply(200, [
       {
         addon: {

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -11,7 +11,11 @@ const shouldSchedule = function (cmdRun) {
 
   beforeEach(() => {
     api = nock('https://api.heroku.com')
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [
       {
         addon: {
           id: 1,

--- a/test/commands/backups/unschedule.js
+++ b/test/commands/backups/unschedule.js
@@ -24,7 +24,7 @@ const shouldUnschedule = function (cmdRun) {
     api.post('/actions/addon-attachments/resolve', {
       app: 'myapp',
       addon_attachment: 'DATABASE_URL',
-      addon_service: 'heroku-postgresql',
+      addon_service: 'heroku-postgresql'
     }).reply(200, [attachment])
     pg = nock('https://postgres-api.heroku.com')
     pg.get('/client/v11/databases/1/transfer-schedules').twice().reply(200, [{name: 'DATABASE_URL', uuid: '100-001'}])

--- a/test/commands/backups/unschedule.js
+++ b/test/commands/backups/unschedule.js
@@ -21,7 +21,11 @@ const shouldUnschedule = function (cmdRun) {
   beforeEach(() => {
     api = nock('https://api.heroku.com')
     api.get('/apps/myapp/addons').reply(200, [addon])
-    api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [attachment])
+    api.post('/actions/addon-attachments/resolve', {
+      app: 'myapp',
+      addon_attachment: 'DATABASE_URL',
+      addon_service: 'heroku-postgresql',
+    }).reply(200, [attachment])
     pg = nock('https://postgres-api.heroku.com')
     pg.get('/client/v11/databases/1/transfer-schedules').twice().reply(200, [{name: 'DATABASE_URL', uuid: '100-001'}])
     pg.delete('/client/v11/databases/1/transfer-schedules/100-001').reply(200)

--- a/test/commands/copy.js
+++ b/test/commands/copy.js
@@ -48,7 +48,7 @@ describe('pg:copy', () => {
       api.post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'DATABASE_URL',
-        addon_service: 'heroku-postgresql',
+        addon_service: 'heroku-postgresql'
       }).reply(200, [attachment])
       api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
       pg.post('/client/v11/databases/1/transfers', {
@@ -73,7 +73,7 @@ describe('pg:copy', () => {
       api.post('/actions/addon-attachments/resolve', {
         app: 'myapp',
         addon_attachment: 'DATABASE_URL',
-        addon_service: 'heroku-postgresql',
+        addon_service: 'heroku-postgresql'
       }).reply(200, [attachment])
       api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
       pg.post('/client/v11/databases/1/transfers', {

--- a/test/commands/copy.js
+++ b/test/commands/copy.js
@@ -45,7 +45,11 @@ describe('pg:copy', () => {
   context('url to heroku', () => {
     beforeEach(() => {
       api.get('/addons/postgres-1').reply(200, addon)
-      api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [attachment])
+      api.post('/actions/addon-attachments/resolve', {
+        app: 'myapp',
+        addon_attachment: 'DATABASE_URL',
+        addon_service: 'heroku-postgresql',
+      }).reply(200, [attachment])
       api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
       pg.post('/client/v11/databases/1/transfers', {
         from_name: 'database bar on foo.com:5432',
@@ -66,7 +70,11 @@ describe('pg:copy', () => {
   context('fails', () => {
     beforeEach(() => {
       api.get('/addons/postgres-1').reply(200, addon)
-      api.post('/actions/addon-attachments/resolve', {app: 'myapp', addon_attachment: 'DATABASE_URL'}).reply(200, [attachment])
+      api.post('/actions/addon-attachments/resolve', {
+        app: 'myapp',
+        addon_attachment: 'DATABASE_URL',
+        addon_service: 'heroku-postgresql',
+      }).reply(200, [attachment])
       api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
       pg.post('/client/v11/databases/1/transfers', {
         from_name: 'database bar on foo.com:5432',

--- a/test/commands/info.js
+++ b/test/commands/info.js
@@ -37,6 +37,7 @@ describe('pg', () => {
   context('with 0 dbs', () => {
     it('shows empty state', () => {
       all = []
+      api.get('/apps/myapp/config-vars').reply(200, {})
 
       return cmd.run({app: 'myapp', args: {}})
       .then(() => expect(cli.stdout, 'to equal', 'myapp has no heroku-postgresql databases.\n'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2061,9 +2061,9 @@ netrc-parser@2.0.1:
   dependencies:
     lex "^1.7.9"
 
-nock@^9.0.13:
-  version "9.0.13"
-  resolved "https://registry.yarnpkg.com/nock/-/nock-9.0.13.tgz#d0bc39ef43d3179981e22b2e8ea069f916c5781a"
+nock@9.1.6:
+  version "9.1.6"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-9.1.6.tgz#16395af4c45b0fd84d1a4a9668154e16fa6624db"
   dependencies:
     chai ">=1.9.2 <4.0.0"
     debug "^2.2.0"
@@ -2072,7 +2072,8 @@ nock@^9.0.13:
     lodash "~4.17.2"
     mkdirp "^0.5.0"
     propagate "0.4.0"
-    qs "^6.0.2"
+    qs "^6.5.1"
+    semver "^5.3.0"
 
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
   version "2.3.6"
@@ -2412,9 +2413,9 @@ pseudomap@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-qs@^6.0.2:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+qs@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 randomatic@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
This fails tests right now, but I wanted to

 1. Open a PR to bump the version to make it clear we're drifting from the CLI and should update
 2. Ideally come up with some way of not drifting in CI, so we test against the node version our customers use

I want to address this after fixing the [current failures in CI](https://circleci.com/gh/heroku/heroku-pg/699#tests/containers/0) (that I have not been able to reproduce in running the tests locally).