### PR TITLE
Attempt to work around issues introduced by heroku rollback

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -76,7 +76,13 @@ exports.presentCredentialAttachments = presentCredentialAttachments
 
 exports.getConnectionDetails = function (attachment, config) {
   const url = require('url')
-  const connstringVar = getUrl(attachment.config_vars.filter((cv) => config[cv].startsWith('postgres://')))
+  const configVars = attachment.config_vars.filter((cv) => {
+    return config[cv] && config[cv].startsWith('postgres://')
+  })
+  if (configVars.length === 0) {
+    throw new Error(`No config vars found for ${attachment.name}; perhaps they were removed as a side effect of ${cli.color.cmd('heroku rollback')}? Use ${cli.color.cmd('heroku addons:attach')} to create a new attachment and then ${cli.color.cmd('heroku addons:detach')} to remove the current attachment.`)
+  }
+  const connstringVar = getUrl(configVars)
 
   // remove _URL from the end of the config var name
   const baseName = connstringVar.slice(0, -4)


### PR DESCRIPTION
The heroku rollback command can leave an app in an inconsistent state:
an add-on and attachment can be present, but the config vars may be
stripped by a rollback. Currently, the pg CLI does not handle this
correctly and will [give a cryptic error](https://support.heroku.com/tickets/544092) in this situation

This attempts to work around that by suggesting that rollback may be
at fault and how to restore the application to a sensible state (by
creating a new attachment and destroying the old one).

The new output looks like
![rollback-sucks](https://user-images.githubusercontent.com/159100/34802757-29781310-f624-11e7-857a-6103d8335a05.png)
(but without the linked plugin notice)