### PR TITLE
Add warning to promote

### DIFF
--- a/commands/credentials.js
+++ b/commands/credentials.js
@@ -41,17 +41,8 @@ function * run (context, heroku) {
     })
   })
 
-  let reset = co.wrap(function * () {
-    const host = require('../lib/host')
-    let db = yield fetcher.addon(app, args.database)
-    cli.warn(`${cli.color.cmd('pg:credentials --reset')} is being deprecated. Please use ${cli.color.cmd('pg:credentials:rotate')} instead.`)
-    yield cli.action(`Resetting credentials on ${cli.color.addon(db.name)}`, co(function * () {
-      yield heroku.post(`/client/v11/databases/${db.id}/credentials_rotation`, {host: host(db)})
-    }))
-  })
-
   if (flags.reset) {
-    yield reset()
+    cli.error(`${cli.color.cmd('pg:credentials --reset')} is deprecated. Please use ${cli.color.cmd('pg:credentials:rotate')} instead.`)
   } else {
     yield showCredentials()
   }
@@ -63,7 +54,7 @@ module.exports = {
   description: 'show information on credentials in the database',
   needsApp: true,
   needsAuth: true,
-  flags: [{name: 'reset', description: 'reset database credentials'}],
+  flags: [{name: 'reset', description: 'DEPRECATED'}],
   args: [{name: 'database', optional: true}],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/commands/promote.js
+++ b/commands/promote.js
@@ -69,8 +69,13 @@ function * run (context, heroku) {
 
   if (releasePhase) {
     yield cli.action('Checking release phase', co(function * () {
-      let releases = (yield heroku.get(`/apps/${app}/releases`))
-          .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+      let releases = yield heroku.request({
+        path: `/apps/${app}/releases`,
+        partial: true,
+        headers: {
+          'Range': `version ..; max=5, order=desc`
+        }
+      })
       let attach = releases.find((release) => release.description.includes('Attach DATABASE'))
       let detach = releases.find((release) => release.description.includes('Detach DATABASE'))
 

--- a/commands/promote.js
+++ b/commands/promote.js
@@ -53,7 +53,9 @@ function * run (context, heroku) {
     promotionMessage = `Promoting ${cli.color.addon(attachment.addon.name)} to ${cli.color.configVar('DATABASE_URL')} on ${cli.color.app(app)}`
   }
 
-  cli.warn('Detaching DATABASE. If you are using the release phase feature (https://devcenter.heroku.com/articles/release-phase), this can cause a failed release.')
+  if (hasCurrent) {
+    cli.warn('Detaching DATABASE. If you are using the release phase feature (https://devcenter.heroku.com/articles/release-phase), pg:promote can cause a failed release. Please double checkthe releases and make sure the database is properly promoted.')
+  }
 
   yield cli.action(promotionMessage, co(function * () {
     yield heroku.post('/addon-attachments', {

--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -139,11 +139,16 @@ module.exports = heroku => {
     return addon
   }
 
+  function * release (appName, id) {
+    return yield heroku.get(`/apps/${appName}/releases/${id}`)
+  }
+
   return {
     addon: co.wrap(addon),
     attachment: co.wrap(attachment),
     all: co.wrap(all),
     database: co.wrap(database),
-    arbitraryAppDB: co.wrap(arbitraryAppDB)
+    arbitraryAppDB: co.wrap(arbitraryAppDB),
+    release: co.wrap(release)
   }
 }

--- a/test/commands/promote.js
+++ b/test/commands/promote.js
@@ -313,4 +313,9 @@ describe('pg:promote when release phase is present', () => {
     return cmd.run({app: 'myapp', args: {}, flags: {}})
         .then(() => expect(cli.stderr, 'to equal', expectedMessage + 'Checking release phase... pg:promote failed because Attach DATABASE release was unsuccessful. Your application is currently running without an attached DATABASE_URL.\n'))
   })
+
+  it('checks release phase for attach failure and detach success', () => {
+    api.get('/apps/myapp/releases').reply(200, [])
+    return expect(cmd.run({app: 'myapp', args: {}, flags: {}}), 'to be rejected')
+  })
 })

--- a/test/commands/promote.js
+++ b/test/commands/promote.js
@@ -62,7 +62,7 @@ describe('pg:promote when argument is database', () => {
       confirm: 'myapp'
     }).reply(201)
     return cmd.run({app: 'myapp', args: {}, flags: {}})
-    .then(() => expect(cli.stderr, 'to equal', expectedMessage.replace("PURPLE", "postgres-1")))
+    .then(() => expect(cli.stderr, 'to equal', expectedMessage.replace('PURPLE', 'postgres-1')))
   })
 
   it('promotes the db and does not create another attachment if current DATABASE has another', () => {
@@ -78,7 +78,7 @@ describe('pg:promote when argument is database', () => {
       confirm: 'myapp'
     }).reply(201)
     return cmd.run({app: 'myapp', args: {}, flags: {}})
-    .then(() => expect(cli.stderr, 'to equal', expectedMessage.replace("PURPLE", "postgres-1")))
+    .then(() => expect(cli.stderr, 'to equal', expectedMessage.replace('PURPLE', 'postgres-1')))
   })
 
   it('does not promote the db if is already is DATABASE', () => {
@@ -138,7 +138,7 @@ describe('pg:promote when argument is a credential attachment', () => {
       confirm: 'myapp'
     }).reply(201)
     return cmd.run({app: 'myapp', args: {}, flags: {}})
-    .then(() => expect(cli.stderr, 'to equal', expectedMessage.replace("postgres-1", "PURPLE")))
+    .then(() => expect(cli.stderr, 'to equal', expectedMessage.replace('postgres-1', 'PURPLE')))
   })
 
   it('promotes the credential and creates another attachment if current DATABASE does not have another and current DATABASE is a credential', () => {

--- a/test/commands/promote.js
+++ b/test/commands/promote.js
@@ -8,8 +8,9 @@ const proxyquire = require('proxyquire')
 
 const expectedMessage = `Ensuring an alternate alias for existing DATABASE_URL... RED_URL
  ▸    Detaching DATABASE. If you are using the release phase feature
- ▸    (https://devcenter.heroku.com/articles/release-phase), this can cause a
- ▸    failed release.
+ ▸    (https://devcenter.heroku.com/articles/release-phase), pg:promote can
+ ▸    cause a failed release. Please double checkthe releases and make sure the
+ ▸    database is properly promoted.
 Promoting PURPLE to DATABASE_URL on myapp... done
 `
 
@@ -240,4 +241,3 @@ describe('pg:promote when argument is a credential attachment', () => {
     return expect(cmd.run({app: 'myapp', args: {}, flags: {}}), 'to be rejected with', err)
   })
 })
-


### PR DESCRIPTION
This adds a warning about potentially failed releases during promotion if release phase is used.

I think there is still an underlying problem with this flow, however. If the `Detach DATABASE` release fails silently and the following `Attach DATABASE` release takes a long time (maybe a long migration) the app will deploy without a database. I think it would be nice to find a way to skip the release for `Detach Database` altogether. Maybe add a flag here to skip release https://github.com/heroku/api/blob/master/lib/api/mediators/attachments/destroyer.rb