### PR TITLE
pg:upgrade --version flag capability added

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -9,6 +9,7 @@ function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   let {app, args, flags} = context
   let db = yield fetcher.addon(app, args.database)
+  let target_version = flags.version
 
   if (util.starterPlan(db)) throw new Error('pg:upgrade is only available for follower production databases')
 
@@ -26,7 +27,7 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 This cannot be undone.`)
 
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db)})
+    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db), version: target_version})
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
   }))
 }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -25,7 +25,7 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 
 This cannot be undone.`)
 
-  let body = flags.version ? {host: host(db), version: flags.version} : {host: host(db)}
+  let body = flags.version ? {host: host(db), body: {version: flags.version}} : {host: host(db)}
 
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
     yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, body)

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -25,10 +25,10 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 
 This cannot be undone.`)
 
-  let body = flags.version ? {host: host(db), body: {version: flags.version}} : {host: host(db), body: {}}
+  let data =  flags.version ? { version: flags.version } : {}
 
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, body)
+    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db), body: data})
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
   }))
 }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -25,7 +25,7 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 
 This cannot be undone.`)
 
-  let body = flags.version ? {host: host(db), body: {version: flags.version}} : {host: host(db)}
+  let body = flags.version ? {host: host(db), body: {version: flags.version}} : {host: host(db), body: {}}
 
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
     yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, body)

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -9,7 +9,6 @@ function * run (context, heroku) {
   const fetcher = require('../lib/fetcher')(heroku)
   let {app, args, flags} = context
   let db = yield fetcher.addon(app, args.database)
-  let target_version = flags.version
 
   if (util.starterPlan(db)) throw new Error('pg:upgrade is only available for follower production databases')
 
@@ -26,8 +25,10 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 
 This cannot be undone.`)
 
+  let body = flags.version ? {host: host(db), version: flags.version} : {host: host(db)}
+
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
-    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db), version: target_version})
+    yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, body)
     cli.action.done(`${cli.color.cmd('heroku pg:wait')} to track status`)
   }))
 }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -39,6 +39,9 @@ module.exports = {
   needsApp: true,
   needsAuth: true,
   args: [{name: 'database', optional: true}],
-  flags: [{name: 'confirm', char: 'c', hasValue: true}],
+  flags: [
+    {name: 'confirm', char: 'c', hasValue: true},
+    {name: 'version', char: 'v', description: 'PostgreSQL version to upgrade to', optional: true, hasValue: true}
+  ],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -25,7 +25,7 @@ ${cli.color.addon(db.name)} will be upgraded to a newer PostgreSQL version, stop
 
 This cannot be undone.`)
 
-  let data =  flags.version ? { version: flags.version } : {}
+  let data = { version: flags.version }
 
   yield cli.action(`Starting upgrade of ${cli.color.addon(db.name)}`, co(function * () {
     yield heroku.post(`/client/v11/databases/${db.id}/upgrade`, {host: host(db), body: data})

--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -41,7 +41,7 @@ module.exports = {
   args: [{name: 'database', optional: true}],
   flags: [
     {name: 'confirm', char: 'c', hasValue: true},
-    {name: 'version', char: 'v', description: 'PostgreSQL version to upgrade to', optional: true, hasValue: true}
+    {name: 'version', char: 'v', description: 'PostgreSQL version to upgrade to', hasValue: true}
   ],
   run: cli.command({preauth: true}, co.wrap(run))
 }

--- a/test/commands/upgrade.js
+++ b/test/commands/upgrade.js
@@ -53,13 +53,4 @@ describe('pg:upgrade', () => {
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', version: '9.6'}})
     .then(() => expect(cli.stderr, 'to equal', 'Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
   })
-
-  it('upgrades db and ignores empty version flag', () => {
-    api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://db1'})
-    pg.get('/client/v11/databases/1').reply(200, {following: 'postgres://db1'})
-    pg.get('/client/v11/databases/1/upgrade_status').reply(200, {})
-    pg.post('/client/v11/databases/1/upgrade').reply(200)
-    return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', version: ''}})
-    .then(() => expect(cli.stderr, 'to equal', 'Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
-  })
 })

--- a/test/commands/upgrade.js
+++ b/test/commands/upgrade.js
@@ -44,4 +44,22 @@ describe('pg:upgrade', () => {
     return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp'}})
     .then(() => expect(cli.stderr, 'to equal', 'Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
   })
+
+  it('upgrades db with version flag', () => {
+    api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://db1'})
+    pg.get('/client/v11/databases/1').reply(200, {following: 'postgres://db1'})
+    pg.get('/client/v11/databases/1/upgrade_status').reply(200, {})
+    pg.post('/client/v11/databases/1/upgrade').reply(200)
+    return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', version: '9.6'}})
+    .then(() => expect(cli.stderr, 'to equal', 'Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
+  })
+
+  it('upgrades db and ignores empty version flag', () => {
+    api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://db1'})
+    pg.get('/client/v11/databases/1').reply(200, {following: 'postgres://db1'})
+    pg.get('/client/v11/databases/1/upgrade_status').reply(200, {})
+    pg.post('/client/v11/databases/1/upgrade').reply(200)
+    return cmd.run({app: 'myapp', args: {}, flags: {confirm: 'myapp', version: ''}})
+    .then(() => expect(cli.stderr, 'to equal', 'Starting upgrade of postgres-1... heroku pg:wait to track status\n'))
+  })
 })


### PR DESCRIPTION
#### What does this PR do?
This is the exposing `--version` flag for enabling upgrades to PostgreSQL 9.6 or 10 from older versions.
#### How has this been tested?

* [x] Specs
* [x] Staging