### PR TITLE
Only allow upgrading follower databases

### DIFF
--- a/commands/upgrade.js
+++ b/commands/upgrade.js
@@ -18,6 +18,11 @@ function * run (context, heroku) {
   ]
 
   if (status.error) throw new Error(status.error)
+
+  if (!replica.following) {
+    throw new Error('pg:upgrade is only available for follower production databases')
+  }
+
   let origin = util.databaseNameFromUrl(replica.following, yield heroku.get(`/apps/${app}/config-vars`))
 
   yield cli.confirmApp(app, flags.confirm, `WARNING: Destructive action


### PR DESCRIPTION
The Shogun upgrade endpoint has a check for this, but we need to
resolve the URL before we call to Shogun, so check this ourselves.

/cc @mrpaulsmith 