### PR TITLE
Fix allAttachments usage of heroku client

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -96,7 +96,9 @@ module.exports = heroku => {
   }
 
   function * allAttachments (app) {
-    let attachments = yield heroku.get(`/apps/${app}/addon-attachments`, {
+    let attachments = yield heroku.request({
+      method: 'GET',
+      path: `/apps/${app}/addon-attachments`,
       headers: {'Accept-Inclusion': 'addon:plan,config_vars'}
     })
     return attachments.filter(a => a.addon.plan.name.startsWith('heroku-postgresql'))


### PR DESCRIPTION
With the code as it is now, I get

```
ERROR: TypeError: callback is not a function
    at requestCallback (/Users/user/heroku/heroku-connect-plugin/node_modules/heroku-cli-util/node_modules/heroku-client/lib/heroku.js:38:21)
    at /Users/user/heroku/heroku-connect-plugin/node_modules/heroku-cli-util/node_modules/heroku-client/lib/request.js:69:21
    at Request.handleSuccess (/Users/user/heroku/heroku-connect-plugin/node_modules/heroku-cli-util/node_modules/heroku-client/lib/request.js:310:5)
    at /Users/user/heroku/heroku-connect-plugin/node_modules/heroku-cli-util/node_modules/heroku-client/lib/request.js:162:14
    at IncomingMessage.<anonymous> (/Users/user/heroku/heroku-connect-plugin/node_modules/heroku-cli-util/node_modules/heroku-client/lib/request.js:393:5)
    at IncomingMessage.emit (events.js:165:20)
    at endReadableNT (_stream_readable.js:1101:12)
    at process._tickCallback (internal/process/next_tick.js:152:19)
Exiting with code: 1
```

With this patch, calling `fetcher(heroku).database(app, 'DATABASE_URL')`
works without error.