### PR TITLE
Minimize the use of util.getConfigVarName

### DIFF
--- a/commands/backups/schedule.js
+++ b/commands/backups/schedule.js
@@ -2,7 +2,6 @@
 
 const co = require('co')
 const cli = require('heroku-cli-util')
-const util = require('../../lib/util')
 
 const TZ = {
   'PST': 'America/Los_Angeles',
@@ -59,7 +58,8 @@ function * run (context, heroku) {
   }
 
   yield cli.action(`Scheduling automatic daily backups of ${cli.color.addon(db.name)} at ${at}`, co(function * () {
-    schedule.schedule_name = util.getConfigVarName(attachment.config_vars)
+    // We've been using config var name as schedule_name historically
+    schedule.schedule_name = attachment.name + '_URL'
 
     yield heroku.post(`/client/v11/databases/${db.id}/transfer-schedules`, {
       body: schedule,

--- a/commands/copy.js
+++ b/commands/copy.js
@@ -5,7 +5,6 @@ const cli = require('heroku-cli-util')
 
 function * run (context, heroku) {
   const url = require('url')
-  const util = require('../lib/util')
   const host = require('../lib/host')
   const pgbackups = require('../lib/pgbackups')(context, heroku)
   const fetcher = require('../lib/fetcher')(heroku)
@@ -32,7 +31,7 @@ function * run (context, heroku) {
       attachment.addon = addon
       return {
         name: attachment.name.replace(/^HEROKU_POSTGRESQL_/, '').replace(/_URL$/, ''),
-        url: config[util.getConfigVarName(addon.config_vars)],
+        url: config[attachment.name + '_URL'],
         attachment,
         confirm: app
       }

--- a/commands/diagnose.js
+++ b/commands/diagnose.js
@@ -15,6 +15,10 @@ function * run (context, heroku) {
     let db = yield fetcher.addon(app, database)
     db = yield heroku.get(`/addons/${db.name}`)
     let config = yield heroku.get(`/apps/${app}/config-vars`)
+    // TODO: util.getConfigVarName is only providing one of config vars of that
+    // addon, we should make sure that we either use the default cred or any
+    // cred that associated with the attachment name that was provided to
+    // pg:diagnose command
     let params = {
       url: config[util.getConfigVarName(db.config_vars)],
       plan: db.plan.name.split(':')[1],

--- a/lib/psql.js
+++ b/lib/psql.js
@@ -57,8 +57,7 @@ function * exec (db, query) {
 }
 
 function * interactive (db) {
-  const pgUtil = require('./util')
-  let name = pgUtil.getConfigVarName(db.attachment.config_vars).replace(/^HEROKU_POSTGRESQL_/, '').replace(/_URL$/, '')
+  let name = db.attachment.name
   let prompt = `${db.attachment.app.name}::${name}%R%# `
   handleSignals()
   let configs = bastion.getConfigs(db)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "url": "https://github.com/heroku/heroku-pg.git"
   },
   "scripts": {
-    "test": "TZ=utc nyc mocha && standard",
+    "test": "TZ=utc mocha && standard",
     "release": "np",
     "prepublishOnly": "oclif-dev manifest",
     "postpublish": "rm .oclif.manifest.json"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "url": "https://github.com/heroku/heroku-pg.git"
   },
   "scripts": {
-    "test": "TZ=utc mocha && standard",
+    "test": "TZ=utc nyc mocha && standard",
     "release": "np",
     "prepublishOnly": "oclif-dev manifest",
     "postpublish": "rm .oclif.manifest.json"

--- a/test/commands/backups/schedule.js
+++ b/test/commands/backups/schedule.js
@@ -24,7 +24,8 @@ const shouldSchedule = function (cmdRun) {
         },
         config_vars: [
           'DATABASE_URL'
-        ]
+        ],
+        name: 'DATABASE'
       }
     ])
     pg = nock('https://postgres-api.heroku.com')

--- a/test/commands/copy.js
+++ b/test/commands/copy.js
@@ -11,22 +11,22 @@ const addon = {
   id: 1,
   name: 'postgres-1',
   app: {name: 'myapp'},
-  config_vars: ['DATABASE_URL'],
+  config_vars: ['READONLY_URL', 'DATABASE_URL', 'HEROKU_POSTGRESQL_RED_URL'],
   plan: {name: 'heroku-postgresql:standard-0'}
 }
 const otherAddon = {
   id: 2,
   name: 'postgres-2',
   app: {name: 'myotherapp'},
-  config_vars: ['DATABASE_URL'],
+  config_vars: ['DATABASE_URL', 'HEROKU_POSTGRESQL_BLUE_URL'],
   plan: {name: 'heroku-postgresql:standard-0'}
 }
 const attachment = {
-  name: 'HEROKU_POSTGRESQL_RED_URL',
+  name: 'HEROKU_POSTGRESQL_RED',
   addon
 }
 const otherAttachment = {
-  name: 'HEROKU_POSTGRESQL_BLUE_URL',
+  name: 'HEROKU_POSTGRESQL_BLUE',
   addon: otherAddon
 }
 
@@ -62,10 +62,14 @@ describe('pg:copy', () => {
       api.get('/addons/postgres-1').reply(200, addon)
       api.post('/actions/addon-attachments/resolve', {
         app: 'myapp',
-        addon_attachment: 'DATABASE_URL',
+        addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
         addon_service: 'heroku-postgresql'
       }).reply(200, [attachment])
-      api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
+      api.get('/apps/myapp/config-vars').reply(200, {
+        READONLY_URL: 'postgres://readonly-heroku/db',
+        DATABASE_URL: 'postgres://heroku/db',
+        HEROKU_POSTGRESQL_RED_URL: 'postgres://heroku/db'
+      })
       pg.post('/client/v11/databases/1/transfers', {
         from_name: 'database bar on foo.com:5432',
         from_url: 'postgres://foo.com/bar',
@@ -76,7 +80,7 @@ describe('pg:copy', () => {
     })
 
     it('copies', () => {
-      return cmd.run({app: 'myapp', args: {source: 'postgres://foo.com/bar', target: 'DATABASE_URL'}, flags: {confirm: 'myapp'}})
+      return cmd.run({app: 'myapp', args: {source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL'}, flags: {confirm: 'myapp'}})
       .then(() => expect(cli.stdout, 'to equal', ''))
       .then(() => expect(cli.stderr, 'to equal', `Starting copy of database bar on foo.com:5432 to RED... done\n${copyingText()}`))
     })
@@ -88,7 +92,7 @@ describe('pg:copy', () => {
       api.get('/addons/postgres-2').reply(200, otherAddon)
       api.post('/actions/addon-attachments/resolve', {
         app: 'myapp',
-        addon_attachment: 'DATABASE_URL',
+        addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
         addon_service: 'heroku-postgresql'
       }).reply(200, [attachment])
       api.post('/actions/addon-attachments/resolve', {
@@ -96,8 +100,15 @@ describe('pg:copy', () => {
         addon_attachment: 'myotherapp::DATABASE_URL',
         addon_service: 'heroku-postgresql'
       }).reply(200, [otherAttachment])
-      api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
-      api.get('/apps/myotherapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/otherdb'})
+      api.get('/apps/myapp/config-vars').reply(200, {
+        READONLY_URL: 'postgres://readonly-heroku/db',
+        DATABASE_URL: 'postgres://heroku/db',
+        HEROKU_POSTGRESQL_RED_URL: 'postgres://heroku/db'
+      })
+      api.get('/apps/myotherapp/config-vars').reply(200, {
+        DATABASE_URL: 'postgres://heroku/otherdb',
+        HEROKU_POSTGRESQL_BLUE_URL: 'postgres://heroku/otherdb'
+      })
       pg.get('/postgres/v0/databases/postgres-1/credentials').reply(200, ['two', 'things'])
       pg.post('/client/v11/databases/2/transfers', {
         from_name: 'RED',
@@ -108,7 +119,7 @@ describe('pg:copy', () => {
       pg.get('/client/v11/apps/myotherapp/transfers/100-001').reply(200, {finished_at: '100', succeeded: true})
     })
     it('copies', () => {
-      return cmd.run({app: 'myapp', args: {source: 'DATABASE_URL', target: 'myotherapp::DATABASE_URL'}, flags: {confirm: 'myapp'}})
+      return cmd.run({app: 'myapp', args: {source: 'HEROKU_POSTGRESQL_RED_URL', target: 'myotherapp::DATABASE_URL'}, flags: {confirm: 'myapp'}})
       .then(() => expect(cli.stdout, 'to equal', ''))
       .then(() => expect(cli.stderr, 'to equal', `Starting copy of RED to BLUE... done\n${credentialWarningText()}${copyingText()}`))
     })
@@ -119,10 +130,14 @@ describe('pg:copy', () => {
       api.get('/addons/postgres-1').reply(200, addon)
       api.post('/actions/addon-attachments/resolve', {
         app: 'myapp',
-        addon_attachment: 'DATABASE_URL',
+        addon_attachment: 'HEROKU_POSTGRESQL_RED_URL',
         addon_service: 'heroku-postgresql'
       }).reply(200, [attachment])
-      api.get('/apps/myapp/config-vars').reply(200, {DATABASE_URL: 'postgres://heroku/db'})
+      api.get('/apps/myapp/config-vars').reply(200, {
+        READONLY_URL: 'postgres://readonly-heroku/db',
+        DATABASE_URL: 'postgres://heroku/db',
+        HEROKU_POSTGRESQL_RED_URL: 'postgres://heroku/db'
+      })
       pg.post('/client/v11/databases/1/transfers', {
         from_name: 'database bar on foo.com:5432',
         from_url: 'postgres://foo.com/bar',
@@ -135,7 +150,7 @@ describe('pg:copy', () => {
 
     it('fails to copy', () => {
       let err = 'An error occurred and the backup did not finish.\n\nfoobar\n\nRun heroku pg:backups:info b001 for more details.'
-      return expect(cmd.run({app: 'myapp', args: {source: 'postgres://foo.com/bar', target: 'DATABASE_URL'}, flags: {confirm: 'myapp'}}), 'to be rejected with', err)
+      return expect(cmd.run({app: 'myapp', args: {source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL'}, flags: {confirm: 'myapp'}}), 'to be rejected with', err)
       .then(() => expect(cli.stdout, 'to equal', ''))
       .then(() => expect(cli.stderr, 'to equal', `Starting copy of database bar on foo.com:5432 to RED... done\n${copyingFailText()}`))
     })


### PR DESCRIPTION
`util.getConfigVarName` is a bad method that just picks up the index 0 value of config var arrays, of its addon. Addon object has config vars, which tells you what kind of config vars are associated with that addon.
For example, if I have the following addon:

```
$ heroku addons:info postgresql-angular-71290 -a keiko-sushi
=== postgresql-angular-71290
Attachments:  keiko-sushi::HEROKU_POSTGRESQL_CYAN
              keiko-sushi::HEROKU_POSTGRESQL_MAROON
Installed at: Mon Mar 27 2017 07:03:51 GMT-0700 (PDT)
Owning app:   keiko-sushi
Plan:         heroku-postgresql:standard-0
Price:        $50/month
State:        created
```

This has two config vars (attachments), `HEROKU_POSTGRESQL_CYAN_URL` and `HEROKU_POSTGRESQL_MAROON_URL`. In this case, we basically don't know if we get CYAN or MAROON with `util.getConfigVarName`.
Usually, whenever you run `heroku pg` command, you know which attachment you're talking about (e.g. you run `heroku pg:copy DATABASE MAROON`) -- especially when the attachment was given with `fetcher.attachment`. This is important that it respects that (in `pg:copy` case, `MAROON` and not `CYAN`), because sometimes that config vars include creds which makes the situation very confusing if that was mistakenly picked up.