### PR TITLE
Fix double port number display issue

### DIFF
--- a/commands/copy.js
+++ b/commands/copy.js
@@ -14,12 +14,12 @@ function * run (context, heroku) {
   let resolve = co.wrap(function * (db) {
     if (db.match(/^postgres:\/\//)) {
       let uri = url.parse(db)
-      let name = uri.path ? uri.path.slice(1) : ''
-      let hostname = `${uri.host}:${uri.port || 5432}`
+      let dbname = uri.path ? uri.path.slice(1) : ''
+      let host = `${uri.hostname}:${uri.port || 5432}`
       return {
-        name: name ? `database ${name} on ${hostname}` : `database on ${hostname}`,
+        name: dbname ? `database ${dbname} on ${host}` : `database on ${host}`,
         url: db,
-        confirm: name || uri.host
+        confirm: dbname || uri.host
       }
     } else {
       let attachment = yield fetcher.attachment(app, db)

--- a/test/commands/copy.js
+++ b/test/commands/copy.js
@@ -76,6 +76,12 @@ describe('pg:copy', () => {
         to_name: 'RED',
         to_url: 'postgres://heroku/db'
       }).reply(200, {uuid: '100-001'})
+      pg.post('/client/v11/databases/1/transfers', {
+        from_name: 'database bar on boop.com:5678',
+        from_url: 'postgres://boop.com:5678/bar',
+        to_name: 'RED',
+        to_url: 'postgres://heroku/db'
+      }).reply(200, {uuid: '100-001'})
       pg.get('/client/v11/apps/myapp/transfers/100-001').reply(200, {finished_at: '100', succeeded: true})
     })
 
@@ -83,6 +89,12 @@ describe('pg:copy', () => {
       return cmd.run({app: 'myapp', args: {source: 'postgres://foo.com/bar', target: 'HEROKU_POSTGRESQL_RED_URL'}, flags: {confirm: 'myapp'}})
       .then(() => expect(cli.stdout, 'to equal', ''))
       .then(() => expect(cli.stderr, 'to equal', `Starting copy of database bar on foo.com:5432 to RED... done\n${copyingText()}`))
+    })
+
+    it('copies (with port number)', () => {
+      return cmd.run({app: 'myapp', args: {source: 'postgres://boop.com:5678/bar', target: 'HEROKU_POSTGRESQL_RED_URL'}, flags: {confirm: 'myapp'}})
+      .then(() => expect(cli.stdout, 'to equal', ''))
+      .then(() => expect(cli.stderr, 'to equal', `Starting copy of database bar on boop.com:5678 to RED... done\n${copyingText()}`))
     })
   })
 


### PR DESCRIPTION
Apparently we were doing something wrong here, `uri.host` is including port number: https://nodejs.org/api/url.html

This will fix https://github.com/heroku/heroku-pg/issues/193

I kinda wanted to ship https://github.com/heroku/heroku-pg/pull/194, but I thought I'd fix one more bug before shipping.