### PR TITLE
pass the app name to shogun

### DIFF
--- a/commands/connection_pooling.js
+++ b/commands/connection_pooling.js
@@ -18,7 +18,7 @@ function * run (context, heroku) {
   let attachment = yield cli.action(
     `Enabling Connection Pooling${credential === 'default' ? '' : ' for credential ' + cli.color.addon(credential)} on ${cli.color.addon(addon.name)} to ${cli.color.app(app)}`,
     heroku.post(`/client/v11/databases/${encodeURIComponent(db.name)}/connection-pooling`, {
-      body: { name: flags.as, credential: credential },
+      body: { name: flags.as, credential: credential, app: app },
       host: host(db)
     })
   )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/plugin-pg",
   "description": "Heroku CLI plugin to manage Postgres.",
-  "version": "2.9.7",
+  "version": "2.9.6",
   "author": "Jeff Dickey (@dickeyxxx)",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pg/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@heroku-cli/plugin-pg",
   "description": "Heroku CLI plugin to manage Postgres.",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "author": "Jeff Dickey (@dickeyxxx)",
   "bugs": {
     "url": "https://github.com/heroku/heroku-pg/issues"

--- a/test/commands/connection_pooling.js
+++ b/test/commands/connection_pooling.js
@@ -55,7 +55,8 @@ describe('pg:connection-polling:attach', () => {
   context('includes a credential', () => {
     beforeEach(() => {
       pg.post(`/client/v11/databases/${addon.name}/connection-pooling`, {
-        credential: readonlyCredential
+        credential: readonlyCredential,
+        app: 'myapp'
       }).reply(201, {name: 'HEROKU_COLOR'})
     })
 
@@ -71,7 +72,8 @@ describe('pg:connection-polling:attach', () => {
     beforeEach(() => {
       pg.post(`/client/v11/databases/${addon.name}/connection-pooling`, {
         credential: defaultCredential,
-        name: attachmentName
+        name: attachmentName,
+        app: 'myapp'
       }).reply(201, {name: attachmentName})
     })
 
@@ -86,7 +88,8 @@ describe('pg:connection-polling:attach', () => {
   context('base command with no credential or attachment name', () => {
     beforeEach(() => {
       pg.post(`/client/v11/databases/${addon.name}/connection-pooling`, {
-        credential: defaultCredential
+        credential: defaultCredential,
+        app: 'myapp'
       }).reply(201, {name: 'HEROKU_COLOR'})
     })
 


### PR DESCRIPTION
To allow cross app connection pooling attachments we need the app name.
We were deriving it from the addon's owning app.