### PR TITLE
Add support for -f in pg:psql

### DIFF
--- a/commands/psql.js
+++ b/commands/psql.js
@@ -15,6 +15,8 @@ function * run (context, heroku) {
   cli.console.error(`--> Connecting to ${cli.color.addon(db.attachment.addon.name)}`)
   if (flags.command) {
     process.stdout.write(yield psql.exec(db, flags.command))
+  } else if (flags.file) {
+    process.stdout.write(yield psql.execFile(db, flags.file))
   } else {
     yield psql.interactive(db)
   }
@@ -26,6 +28,7 @@ let cmd = {
   needsAuth: true,
   flags: [
     {name: 'command', char: 'c', description: 'SQL command to run', hasValue: true},
+    {name: 'file', char: 'f', description: 'SQL file to run', hasValue: true},
     {name: 'credential', description: 'credential to use', hasValue: true}
   ],
   args: [{name: 'database', optional: true}],

--- a/test/commands/psql.js
+++ b/test/commands/psql.js
@@ -42,4 +42,13 @@ describe('psql', () => {
     .then(() => expect(cli.stderr, 'to equal', '--> Connecting to postgres-1\n'))
     .then(() => psql.exec.restore())
   }))
+
+  it('runs psql with file', sinon.test(() => {
+    let psql = require('../../lib/psql')
+    sinon.stub(psql, 'execFile').returns(Promise.resolve(''))
+    return cmd.run({args: {}, flags: {file: 'test.sql'}})
+    .then(() => expect(cli.stdout, 'to equal', ''))
+    .then(() => expect(cli.stderr, 'to equal', '--> Connecting to postgres-1\n'))
+    .then(() => psql.execFile.restore())
+  }))
 })

--- a/test/lib/psql.js
+++ b/test/lib/psql.js
@@ -43,6 +43,7 @@ describe('psql', () => {
 
   afterEach(() => {
     Math.random.restore()
+    tunnelStub.reset()
   })
 
   describe('exec', () => {
@@ -110,6 +111,78 @@ describe('psql', () => {
         }
       )
       return psql.exec(bastionDb, 'SELECT NOW();', 1000)
+      .then(() => expect(
+        tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true))
+      .then(() => cp.verify())
+      .then(() => cp.restore())
+    }))
+  })
+
+  describe('execFile', () => {
+    it('runs psql', sinon.test(() => {
+      let cp = sinon.mock(require('child_process'))
+      let env = Object.assign({}, process.env, {
+        PGAPPNAME: 'psql non-interactive',
+        PGSSLMODE: 'prefer',
+        PGUSER: 'jeff',
+        PGPASSWORD: 'pass',
+        PGDATABASE: 'mydb',
+        PGPORT: 5432,
+        PGHOST: 'localhost'
+      })
+      let opts = {env: env, encoding: 'utf8', stdio: [ 'ignore', 'pipe', 'inherit' ]}
+      cp.expects('spawn').withExactArgs('psql', ['-f', 'test.sql'], opts).once().returns(
+        {
+          stdout: {
+            on: (key, callback) => {
+              if (key === 'data') {
+                callback(new Error('2001-01-01T00:00:00.000UTC'))
+              }
+            }
+          },
+          on: (key, callback) => {
+            if (key === 'close') {
+              callback(new Error(0))
+            } else if (key === 'error') {
+              callback(null)
+            }
+          }
+        }
+      )
+      return psql.execFile(db, 'test.sql')
+      .then(() => cp.verify())
+      .then(() => cp.restore())
+    }))
+    it('opens an SSH tunnel and runs psql for bastion databases', sinon.test(() => {
+      let cp = sinon.mock(require('child_process'))
+      let tunnelConf = {
+        username: 'bastion',
+        host: 'bastion-host',
+        privateKey: 'super-private-key',
+        dstHost: 'localhost',
+        dstPort: 5432,
+        localHost: '127.0.0.1',
+        localPort: 49152
+      }
+      cp.expects('spawn').withArgs('psql', ['-f', 'test.sql']).once().returns(
+        {
+          stdout: {
+            on: (key, callback) => {
+              if (key === 'data') {
+                callback(new Error('2001-01-01T00:00:00.000UTC'))
+              }
+            }
+          },
+          on: (key, callback) => {
+            if (key === 'close') {
+              callback(new Error(0))
+            } else if (key === 'error') {
+              callback(null)
+            }
+          }
+        }
+      )
+      return psql.execFile(bastionDb, 'test.sql', 1000)
       .then(() => expect(
         tunnelStub.withArgs(tunnelConf).calledOnce, 'to equal', true))
       .then(() => cp.verify())

--- a/yarn.lock
+++ b/yarn.lock
@@ -3689,7 +3689,7 @@ semver-diff@^2.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-semver@^5.5.0:
+semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 


### PR DESCRIPTION
Closes #201 

The implementation is heavily inspired by the support of `-c`