### PR TITLE
Adding try/catch to attachment filtering

### DIFF
--- a/lib/fetcher.js
+++ b/lib/fetcher.js
@@ -58,7 +58,18 @@ module.exports = heroku => {
         throw new Error(`${cli.color.app(app)} has no databases`)
       }
 
-      matches = attachments.filter(attachment => config[db] && config[db] === config[pgUtil.getConfigVarName(attachment.config_vars)])
+      matches = attachments.filter(attachment => {
+        let configVarName
+
+        try {
+          configVarName = pgUtil.getConfigVarName(attachment.config_vars)
+        } catch (error) {
+          debug(`found an attachment without any exported config_vars: ${attachment.name}`)
+          configVarName = null
+        }
+
+        return config[db] && config[db] === config[configVarName]
+      })
 
       if (matches.length === 0) {
         let validOptions = attachments.map(attachment => pgUtil.getConfigVarName(attachment.config_vars))


### PR DESCRIPTION
This fixes a bug that causes `pg:psql` and other commands to break if an addon is created that hasn't yet exported config variables. This is a rather uncommon situation but a provisioning bug shouldn't prevent us from using most `pg:*` commands.